### PR TITLE
Fixed issue with TouchId and hasValueForKey:

### DIFF
--- a/Pod/Classes/A0SimpleKeychain.m
+++ b/Pod/Classes/A0SimpleKeychain.m
@@ -86,7 +86,7 @@
 }
 
 - (BOOL)hasValueForKey:(NSString *)key {
-    if (key) {
+    if (!key) {
         return NO;
     }
     NSDictionary *query = [self queryFindByKey:key message:nil];


### PR DESCRIPTION
## TouchID issue:

There is a problem when updating an item that was stored with touchId. SecItemUpdate() is not 
allowed on such items. See Known Issues in https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-8.0/
## hasValueForKey:

Always returned NO, when the key was != null. 
