### PR TITLE
TouchId: Determine reason for failed dataForKey: call

### DIFF
--- a/Pod/Classes/A0SimpleKeychain.h
+++ b/Pod/Classes/A0SimpleKeychain.h
@@ -60,6 +60,54 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
     A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly
 };
 
+#define A0ErrorDomain @"A0ErrorDomain"
+
+/**
+ * Enum with keychain error codes. It's a mirror of the keychain error codes. 
+ */
+typedef NS_ENUM(NSInteger, A0SimpleKeychainError) {
+    /**
+     * @see errSecSuccess
+     */
+    A0SimpleKeychainErrorNoError = 0,
+    /**
+     * @see errSecUnimplemented
+     */
+    A0SimpleKeychainErrorUnimplemented = -4,
+    /**
+     * @see errSecParam
+     */
+    A0SimpleKeychainErrorWrongParameter = -50,
+    /**
+     * @see errSecAllocate
+     */
+    A0SimpleKeychainErrorAllocation = -108,
+    /**
+     * @see errSecNotAvailable
+     */
+    A0SimpleKeychainErrorNotAvailable = -25291,
+    /**
+     * @see errSecAuthFailed
+     */
+    A0SimpleKeychainErrorAuthFailed = -25293,
+    /**
+     * @see errSecDuplicateItem
+     */
+    A0SimpleKeychainErrorDuplicateItem = -25299,
+    /**
+     * @see errSecItemNotFound
+     */
+    A0SimpleKeychainErrorItemNotFound = -25300,
+    /**
+     * @see errSecInteractionNotAllowed
+     */
+    A0SimpleKeychainErrorInteractionNotAllowed = -25308,
+    /**
+     * @see errSecDecode
+     */
+    A0SimpleKeychainErrorDecode = -26275
+};
+
 /**
  *  A simple helper class to deal with storing and retrieving values from iOS Keychain.
  *  It has support for sharing keychain items using Access Group and also for iOS 8 fine grained accesibility over a specific Kyechain Item (Using Access Control).
@@ -218,6 +266,18 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
  *  @return the value or nil if an error occurs.
  */
 - (NSData *)dataForKey:(NSString *)key promptMessage:(NSString *)message;
+
+/**
+ *  Fetches a NSData from the keychain
+ *
+ *  @param key     the key of the value to fetch
+ *  @param message prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param err     Returns an error, if the item cannot be retrieved. F.e. item not found 
+ *                 or user authentication failed in TouchId case.
+ *
+ *  @return the value or nil if an error occurs.
+ */
+- (NSData *)dataForKey:(NSString *)key promptMessage:(NSString *)message error:(NSError**)err;
 
 /**
  *  Checks if a key has a value in the Keychain

--- a/Pod/Classes/A0SimpleKeychain.h
+++ b/Pod/Classes/A0SimpleKeychain.h
@@ -60,7 +60,7 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
     A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly
 };
 
-#define A0ErrorDomain @"A0ErrorDomain"
+#define A0ErrorDomain @"com.auth0.simplekeychain"
 
 /**
  * Enum with keychain error codes. It's a mirror of the keychain error codes. 

--- a/Pod/Classes/A0SimpleKeychain.m
+++ b/Pod/Classes/A0SimpleKeychain.m
@@ -234,29 +234,30 @@
 }
 
 - (NSString*)stringForSecStatus:(OSStatus)status {
+    
     switch(status) {
         case errSecSuccess:
-            return @"errSecSuccess: No error";
+            return NSLocalizedStringFromTable(@"errSecSuccess: No error", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecUnimplemented:
-            return @"errSecUnimplemented: Function or operation not implemented";
+            return NSLocalizedStringFromTable(@"errSecUnimplemented: Function or operation not implemented", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecParam:
-            return @"errSecParam: One or more parameters passed to the function were not valid";
+            return NSLocalizedStringFromTable(@"errSecParam: One or more parameters passed to the function were not valid", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecAllocate:
-            return @"errSecAllocate: Failed to allocate memory";
+            return NSLocalizedStringFromTable(@"errSecAllocate: Failed to allocate memory", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecNotAvailable:
-            return @"errSecNotAvailable: No trust results are available";
+            return NSLocalizedStringFromTable(@"errSecNotAvailable: No trust results are available", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecAuthFailed:
-            return @"errSecAuthFailed: Authorization/Authentication failed";
+            return NSLocalizedStringFromTable(@"errSecAuthFailed: Authorization/Authentication failed", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecDuplicateItem:
-            return @"errSecDuplicateItem: The item already exists";
+            return NSLocalizedStringFromTable(@"errSecDuplicateItem: The item already exists", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecItemNotFound:
-            return @"errSecItemNotFound: The item cannot be found";
+            return NSLocalizedStringFromTable(@"errSecItemNotFound: The item cannot be found", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecInteractionNotAllowed:
-            return @"errSecInteractionNotAllowed: Interaction with the Security Server is not allowed";
+            return NSLocalizedStringFromTable(@"errSecInteractionNotAllowed: Interaction with the Security Server is not allowed", @"SimpleKeychain", @"Possible error from keychain. ");
         case errSecDecode:
-            return @"errSecDecode: Unable to decode the provided data";
+            return NSLocalizedStringFromTable(@"errSecDecode: Unable to decode the provided data", @"SimpleKeychain", @"Possible error from keychain. ");
         default:
-            return [NSString stringWithFormat:@"Unknown error code %d", status];
+            return [NSString stringWithFormat:NSLocalizedStringFromTable(@"Unknown error code %d", @"SimpleKeychain", @"Possible error from keychain. "), status];
     }
 }
 


### PR DESCRIPTION
Added overload for dataForKey: that returns an error code to the caller.

The main reason is to determine the cause for a nil return value in a TouchId situation.
Did the method return nil because the key really was not found, or did the user simply
fail to authenticate or cancel the authentication request.