### PR TITLE
Initialise variable in stringForKey

### DIFF
--- a/Pod/Classes/A0SimpleKeychain.m
+++ b/Pod/Classes/A0SimpleKeychain.m
@@ -58,7 +58,7 @@
 
 - (NSString *)stringForKey:(NSString *)key promptMessage:(NSString *)message {
     NSData *data = [self dataForKey:key promptMessage:message];
-    NSString *string;
+    NSString *string = nil;
     if (data) {
         string = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
     }


### PR DESCRIPTION
Init the ``string`` variable in stringForKey to prevent compiler errors with ``-Wsometimes-uninitialised``.

As it currently is, compilation in my project fails like so:

```
A0SimpleKeychain.m:62:9: error: variable 'string' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
    if (data) {
        ^~~~
A0SimpleKeychain.m:65:12: note: uninitialized use occurs here
    return string;
           ^~~~~~
A0SimpleKeychain.m:62:5: note: remove the 'if' if its condition is always true
    if (data) {
    ^~~~~~~~~~
A0SimpleKeychain.m:61:21: note: initialize the variable 'string' to silence this warning
    NSString *string;
                    ^
                     = nil
1 error generated.
```

This PR implements the given suggestion, allowing my project to compile.