### PR TITLE
Added watchos deployment target

### DIFF
--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -15,6 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.10'
+  s.watchos.deployment_target = '2.0'
   s.requires_arc = true
 
   s.source_files = 'SimpleKeychain/*.{h,m}'


### PR DESCRIPTION
A deployment target for Watch OS was added to the podspec to be able to use SimpleKeychain on Watch OS2.
