### PR TITLE
Fixing “non-modular header inside framework module” error by changing import statements.

### DIFF
--- a/SimpleKeychain/SimpleKeychain.h
+++ b/SimpleKeychain/SimpleKeychain.h
@@ -30,5 +30,5 @@ FOUNDATION_EXPORT const unsigned char SimpleKeychainVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <SimpleKeychain/PublicHeader.h>
 
-#import <SimpleKeychain/A0SimpleKeychain.h>
-#import <SimpleKeychain/A0SimpleKeychain+KeyPair.h>
+#import "A0SimpleKeychain.h"
+#import "A0SimpleKeychain+KeyPair.h"


### PR DESCRIPTION
This may help others. I had to modify these two import statements in order to get my Objective-C project to compile.