### PR TITLE
Additional query attributes

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -141,6 +141,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic) BOOL useAccessControl;
 
+
+/**
+ * Additional attributes to associate with the keychain when querying items for adding or retriving.
+ * Default value is nil.
+ * You can use this to provide attributes like kSecAttrSynchronizable, etc. By default, only the kSecAttrService and kSecClass attributes are used.
+ */
+@property (nonatomic, copy) NSDictionary *additionalAttributes;
+
 ///---------------------------------------------------
 /// @name Initialization
 ///---------------------------------------------------

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -289,7 +289,17 @@
     if (self.additionalAttributes != nil) {
         [attributes addEntriesFromDictionary:self.additionalAttributes];
     }
-
+    
+    /*
+     * if the kSecAttrSyncrhonizable is defined, the docs mention the following:
+     *Items stored or obtained using the kSecAttrSynchronizable key cannot specify SecAccessRef based access control with kSecAttrAccess.
+     */
+#if TARGET_OS_MACOS
+    if ([self.additionalAttributes valueForKey:(__bridge id)kSecAttrSynchronizable]) {
+        [attributes removeObjectForKey:(__bridge  id)kSecAttrAccess];
+    }
+#endif 
+    
     return attributes;
 }
 

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -285,6 +285,10 @@
         attributes[(__bridge id)kSecAttrAccessGroup] = self.accessGroup;
     }
 #endif
+    
+    if (self.additionalAttributes != nil) {
+        [attributes addEntriesFromDictionary:self.additionalAttributes];
+    }
 
     return attributes;
 }


### PR DESCRIPTION
This patch introduces the `additionalAttributes` property when creating a `A0SimpleKeychain` instance. 

This allows the developers to add additional attributes as desired. In my case, I needed something as simple as:
```objc
keychain.additionalAttributes = @{(__bridge id)kSecAttrSynchronizable: (__bridge id)kSecAttrSynchronizableAny};
``` 

for synchronising certain `SecItem`s across the iCloud Keychain service. 