### PR TITLE
Add module map generation.

### DIFF
--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -17,7 +17,9 @@ Pod::Spec.new do |s|
   s.osx.deployment_target = '10.10'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
+
   s.requires_arc = true
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 
   s.source_files = 'SimpleKeychain/*.{h,m}'
 end


### PR DESCRIPTION
**Goal**
Allow Auth0 to be added as a static library via Cocoapods.

**Workarounds**
1. Add `use_modular_headers!` to the Podfile.
2. Add `pod 'SimpleKeychain', :modular_headers => true` to the Podfile.

**Additional Reading**
[CocoaPods 1.5.0 - Swift Static Libraries :: *Modular Headers*](http://blog.cocoapods.org/CocoaPods-1.5.0/#modular-headers)