### PR TITLE
Reuse LocalAuthentication context

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -21,7 +21,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-
+#import <LocalAuthentication/LocalAuthentication.h>
 ///---------------------------------------------------
 /// @name Keychain Items Accessibility Values
 ///---------------------------------------------------
@@ -141,6 +141,13 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (assign, nonatomic) BOOL useAccessControl;
 
+
+/**
+*  LocalAuthenticationContext used to access items. Default value is a new LAContext object
+*/
+@property (readonly, nullable, nonatomic) LAContext *localAuthenticationContext;
+
+
 ///---------------------------------------------------
 /// @name Initialization
 ///---------------------------------------------------
@@ -170,6 +177,12 @@ NS_ASSUME_NONNULL_BEGIN
  *  @return an initialised instance.
  */
 - (instancetype)initWithService:(NSString *)service accessGroup:(nullable NSString *)accessGroup;
+
+/**
+ *  The duration for which Touch ID authentication reuse is allowable.
+ *  Maximun value is LATouchIDAuthenticationMaximumAllowableReuseDuration
+ */
+- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration;
 
 ///---------------------------------------------------
 /// @name Store values

--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -21,7 +21,13 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+
+#if __has_include("LocalAuthentication/LocalAuthentication.h")
+
 #import <LocalAuthentication/LocalAuthentication.h>
+
+#endif
+
 ///---------------------------------------------------
 /// @name Keychain Items Accessibility Values
 ///---------------------------------------------------
@@ -61,6 +67,9 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
 };
 
 #define A0ErrorDomain @"com.auth0.simplekeychain"
+
+#define A0LocalAuthenticationCapable __IPHONE_OS_VERSION_MIN_ALLOWED >= 80000 || __MAC_OS_X_VERSION_MIN_ALLOWED >= 101200
+
 
 /**
  * Enum with keychain error codes. It's a mirror of the keychain error codes. 
@@ -145,8 +154,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
 *  LocalAuthenticationContext used to access items. Default value is a new LAContext object
 */
+#if A0LocalAuthenticationCapable
 @property (readonly, nullable, nonatomic) LAContext *localAuthenticationContext;
-
+#endif
 
 ///---------------------------------------------------
 /// @name Initialization
@@ -182,7 +192,9 @@ NS_ASSUME_NONNULL_BEGIN
  *  The duration for which Touch ID authentication reuse is allowable.
  *  Maximun value is LATouchIDAuthenticationMaximumAllowableReuseDuration
  */
-- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration;
+#if A0LocalAuthenticationCapable
+- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration API_AVAILABLE(ios(8), macosx(10.12)) API_UNAVAILABLE(watchos, tvos);
+#endif
 
 ///---------------------------------------------------
 /// @name Store values

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -44,8 +44,20 @@
         _accessGroup = accessGroup;
         _defaultAccessiblity = A0SimpleKeychainItemAccessibleAfterFirstUnlock;
         _useAccessControl = NO;
+        _localAuthenticationContext = [LAContext new];
+        _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = 0;
     }
     return self;
+}
+
+- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration {
+    if (duration <= 0) {
+        _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = 0;
+    } else if (duration >= LATouchIDAuthenticationMaximumAllowableReuseDuration) {
+        _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = LATouchIDAuthenticationMaximumAllowableReuseDuration;
+    } else {
+        _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = duration;
+    }
 }
 
 - (NSString *)stringForKey:(NSString *)key {
@@ -279,6 +291,8 @@
     NSMutableDictionary *attributes = [@{
                                          (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
                                          (__bridge id)kSecAttrService: self.service,
+                                         (__bridge id)kSecUseAuthenticationContext: _localAuthenticationContext,
+                                         (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUIAllow,
                                          } mutableCopy];
 #if !TARGET_IPHONE_SIMULATOR
     if (self.accessGroup) {

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -44,13 +44,19 @@
         _accessGroup = accessGroup;
         _defaultAccessiblity = A0SimpleKeychainItemAccessibleAfterFirstUnlock;
         _useAccessControl = NO;
+        
+// This does not apply to watchOS & tvOS
+#if A0LocalAuthenticationCapable
         _localAuthenticationContext = [LAContext new];
         _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = 0;
+#endif
     }
     return self;
 }
 
 - (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration {
+// This does not apply to watchOS & tvOS
+#if A0LocalAuthenticationCapable
     if (duration <= 0) {
         _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = 0;
     } else if (duration >= LATouchIDAuthenticationMaximumAllowableReuseDuration) {
@@ -58,6 +64,7 @@
     } else {
         _localAuthenticationContext.touchIDAuthenticationAllowableReuseDuration = duration;
     }
+#endif
 }
 
 - (NSString *)stringForKey:(NSString *)key {
@@ -291,9 +298,13 @@
     NSMutableDictionary *attributes = [@{
                                          (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
                                          (__bridge id)kSecAttrService: self.service,
-                                         (__bridge id)kSecUseAuthenticationContext: _localAuthenticationContext,
                                          (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUIAllow,
                                          } mutableCopy];
+    
+#if A0LocalAuthenticationCapable
+    [attributes setObject:_localAuthenticationContext forKey:(__bridge id)kSecUseAuthenticationContext];
+#endif
+    
 #if !TARGET_IPHONE_SIMULATOR
     if (self.accessGroup) {
         attributes[(__bridge id)kSecAttrAccessGroup] = self.accessGroup;


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Added an instance of LAContext to the Keychain class in order to reuse it.
- Expose the LAContext as a read property in order to reuse it outside of the Keychain (In Auth0's CredentialManager, for example)

### References

Please include relevant links supporting this change such as a:

- fix issue: https://github.com/auth0/SimpleKeychain/issues/73 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If helpful, please include manual testing steps as well. 

1. Create an instance of Keychain and configure it to use LocalAuthentication an access when the device is unlocked

```swift
keychain = A0SimpleKeychain()
keychain.useAccessControl = true
keychain.defaultAccessiblity = .whenUnlockedThisDeviceOnly
keychain.setTouchIDAuthenticationAllowableReuseDuration(5.0)

let r1 = keychain.setString("TEST 1A", forKey: "KEY 1", promptMessage: "P1")
let r2 = keychain.setString("TEST 2A", forKey: "KEY 2", promptMessage: "P2")       

let v1 = keychain.string(forKey: "KEY 1", promptMessage: "P1B")
let v2 = keychain.string(forKey: "KEY 2", promptMessage: "P2B")
```

2. Enable FaceID via declaration in Info.plist

```
<key>NSFaceIDUsageDescription</key>
<string>Access Keychain</string>
```

3. When running the code in (1) the Passcode / Touch ID / Face ID local authentication will be asked only once (will be reused). With the current code it's asked every time a keychain operation is performed.

[ ] This change adds unit test coverage (or why not)

It does not include Unit Test. The Test requires UI Interaction in order to see the behavior

[X] This change has been tested on the latest version of the platform/language or why not

Tested on iOS 13.2

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[X] All existing and new tests complete without errors
