### PR TITLE
Swift package manager support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,9 @@ jobs:
       - run:
           name: Pod Lib Lint
           command: bundle exec fastlane ios pod_lint
+      - run:
+          name: SwiftPM Test
+          command: swift test
       - run: |
           bash <(curl -s https://codecov.io/bash) -J 'SimpleKeychain' 
       - save_cache:

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ fastlane/report.xml
 **/test_output/
 .env
 fastlane/screenshots/
+
+#SwiftPM
+.build
+Package.resolved

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -6,10 +6,10 @@ import PackageDescription
 let package = Package(
     name: "SimpleKeychain",
     platforms: [
-        .iOS("9.0"),
-        .macOS("10.11"),
-        .watchOS("2.0"),
-        .tvOS("9.0"),
+        .iOS(.v9),
+        .macOS(.v10_11),
+        .watchOS(.v2),
+        .tvOS(.v9)
     ],
     products: [
         .library(
@@ -20,7 +20,6 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Quick/Quick", from: "2.0.0"),
         .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
-
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "SimpleKeychain",
+    platforms: [
+        .iOS("9.0"),
+        .macOS("10.11"),
+        .watchOS("2.0"),
+        .tvOS("9.0"),
+    ],
+    products: [
+        .library(
+            name: "SimpleKeychain",
+            targets: ["SimpleKeychain"]
+        ),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Quick/Quick", from: "2.0.0"),
+        .package(url: "https://github.com/Quick/Nimble", from: "8.0.0"),
+
+    ],
+    targets: [
+        .target(
+            name: "SimpleKeychain",
+            dependencies: [],
+            path: "SimpleKeychain"
+        ),
+        .testTarget(
+            name: "SimpleKeychainTests",
+            dependencies: ["SimpleKeychain", "Quick", "Nimble"],
+            path: "SimpleKeychainTests"
+        ),
+    ]
+)

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -18,6 +18,7 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
   s.requires_arc = true
-
   s.source_files = 'SimpleKeychain/*.{h,m}'
+  s.exclude_files = 'SimpleKeychain/include/*'
+
 end

--- a/SimpleKeychain/include/A0SimpleKeychain+KeyPair.h
+++ b/SimpleKeychain/include/A0SimpleKeychain+KeyPair.h
@@ -1,0 +1,1 @@
+../A0SimpleKeychain+KeyPair.h

--- a/SimpleKeychain/include/A0SimpleKeychain.h
+++ b/SimpleKeychain/include/A0SimpleKeychain.h
@@ -1,0 +1,1 @@
+../A0SimpleKeychain.h


### PR DESCRIPTION
### Changes

Adds support for building this package with the swift package manager.
Swift Package Manager is very opinionated about the file structure for packages, so in order to minimise the diff for this PR I have tried to keep the existing structure in place. There is an additional `include` folder containing the required headers symlinked in order to generate the umbrella header.

I have hopefully excluded this from the pod spec properly.

### References
Adds support requested in #71 
Opens the path to https://github.com/auth0/Auth0.swift/issues/306

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If helpful, please include manual testing steps as well. 

[x] This change adds unit test coverage (or why not)
I have added a step the the Circle CI config to run `swift test`

[x] This change has been tested on the latest version of the platform/language or why not
Tested with the App

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
