### PR TITLE
Don't require passing CI to report coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,6 @@
+codecov:
+  require_ci_to_pass: no
+
 coverage:
   precision: 2
   round: down
@@ -16,4 +19,5 @@ coverage:
         target: auto
         threshold: 2
         if_no_uploads: error
+
 comment: false


### PR DESCRIPTION
### Changes

This PR changes Codecov's settings to not require the CI checks to pass in order to report the coverage.

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors
