### PR TITLE
Mark up A0SimpleKeychain+KeyPair to admit that keys may not exist

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain+KeyPair.h
+++ b/SimpleKeychain/A0SimpleKeychain+KeyPair.h
@@ -74,7 +74,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @return SecKeyRef of RSA Key
  */
-- (SecKeyRef)keyRefOfRSAKeyWithTag:(NSString *)keyTag;
+- (nullable SecKeyRef)keyRefOfRSAKeyWithTag:(NSString *)keyTag;
 
 /**
  *  Checks if a RSA key exists with a given tag.
@@ -98,7 +98,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  
  *  @deprecated 0.2.0
  */
-- (NSData *)publicRSAKeyDataForTag:(NSString *)keyTag __attribute__((deprecated));
+- (nullable NSData *)publicRSAKeyDataForTag:(NSString *)keyTag __attribute__((deprecated));
 
 @end
 


### PR DESCRIPTION
### Changes

- Declare `-[A0SimpleKeychain keyRefOfRSAKeyWithTag:]` and `-[A0SimpleKeychain publicRSAKeyDataForTag:]` as having nullable return types to match their implementations.

### References

It seems like it should be valid to ask for a key that does not exist, and the implementations of these functions gracefully return `null` in this scenario.
- [-[A0SimpleKeychain keyRefOfRSAKeyWithTag:]](https://github.com/auth0/SimpleKeychain/blob/master/SimpleKeychain/A0SimpleKeychain%2BKeyPair.m#L120)
- [-[A0SimpleKeychain publicRSAKeyDataForTag:]](https://github.com/auth0/SimpleKeychain/blob/master/SimpleKeychain/A0SimpleKeychain%2BKeyPair.m#L72)

Closes #85.

### Testing

This is a compile-time change only, though it will have an impact on source compatibility.

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
