### PR TITLE
Disabled LAContext attribute in simulator [SDK-1476]

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -300,15 +300,15 @@
                                          (__bridge id)kSecAttrService: self.service,
                                          (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUIAllow,
                                          } mutableCopy];
-    
-#if A0LocalAuthenticationCapable
-    [attributes setObject:_localAuthenticationContext forKey:(__bridge id)kSecUseAuthenticationContext];
-#endif
-    
+
 #if !TARGET_IPHONE_SIMULATOR
     if (self.accessGroup) {
         attributes[(__bridge id)kSecAttrAccessGroup] = self.accessGroup;
     }
+    
+#if A0LocalAuthenticationCapable
+    attributes[(__bridge id)kSecUseAuthenticationContext] = self.localAuthenticationContext;
+#endif
 #endif
 
     return attributes;


### PR DESCRIPTION
### Changes

The iOS 13.4 simulator seems to have introduced a bug in the behavior of `SecItemCopyMatching` when a `LAContext` instance is used in the query.

Using any key will result in a successful `OSCode`:

```swift
let laContext = LAContext()

let loadQuery = [
  kSecClass as String: kSecClassGenericPassword,
  kSecAttrService as String: UUID().uuidString,
  kSecUseAuthenticationContext as String: laContext // 👈🏻
] as [String : Any]

let result = SecItemCopyMatching(loadQuery as CFDictionary, nil)
print("Result: \(result == errSecSuccess)")

// Result: true
```

And no data will actually be retrieved:

```swift
let laContext = LAContext()
let key = "foo"

let saveQuery = [
    kSecClass as String: kSecClassGenericPassword,
    kSecAttrService as String: key,
    kSecValueData as String: "bar".data(using: .utf8)!,
    kSecUseAuthenticationContext as String: laContext // 👈🏻
] as [String : Any]

SecItemAdd(saveQuery as CFDictionary, nil)

let loadQuery = [
    kSecClass as String: kSecClassGenericPassword,
    kSecAttrService as String: key,
    kSecReturnData as String: kCFBooleanTrue!,
    kSecUseAuthenticationContext as String: laContext // 👈🏻
] as [String : Any]

var dataTypeRef: CFTypeRef?
SecItemCopyMatching(loadQuery as CFDictionary, &dataTypeRef)

print(String(data: (dataTypeRef as? Data) ?? "nope!".data(using: .utf8)!, encoding: .utf8)!)

// nope!
```

This PR disables the use of `kSecUseAuthenticationContext` in simulator targets.

### References

Fixes https://github.com/auth0/SimpleKeychain/issues/90

### Testing

[ ] This change adds unit test coverage (or why not)
[X] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors
