### PR TITLE
Release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.11.1](https://github.com/auth0/SimpleKeychain/tree/0.11.1) (2020-03-26)
+[Full Changelog](https://github.com/auth0/SimpleKeychain/compare/0.11.0...0.11.1)
+
+**Fixed**
+- Disabled LAContext attribute in simulator [SDK-1476] [\#91](https://github.com/auth0/SimpleKeychain/pull/91) ([Widcket](https://github.com/Widcket))
+
 ## [0.11.0](https://github.com/auth0/SimpleKeychain/tree/0.11.0) (2020-02-27)
 [Full Changelog](https://github.com/auth0/SimpleKeychain/compare/0.10.0...0.11.0)
 

--- a/SimpleKeychain/Info.plist
+++ b/SimpleKeychain/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.11.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SimpleKeychainApp/Info.plist
+++ b/SimpleKeychainApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.11.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SimpleKeychainTests/Info.plist
+++ b/SimpleKeychainTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.11.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/tvOSTestHost/Info.plist
+++ b/tvOSTestHost/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.11.0</string>
+	<string>0.11.1</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
**Fixed**
- Disabled LAContext attribute in simulator [SDK-1476] [\#91](https://github.com/auth0/SimpleKeychain/pull/91) ([Widcket](https://github.com/Widcket))

[SDK-1476]: https://auth0team.atlassian.net/browse/SDK-1476