### PR TITLE
Fixed macOS version check on Big Sur

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -68,7 +68,7 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
 
 #define A0ErrorDomain @"com.auth0.simplekeychain"
 
-#define A0LocalAuthenticationCapable (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= 101200)
+#define A0LocalAuthenticationCapable (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_2)
 
 
 /**


### PR DESCRIPTION
### Changes

On macOS Big Sur, the version number for macOS 10.12 is no longer `101200` but `1020`. This PR replaces the hardcoded number with a macro so it always resolves to the right number.

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If helpful, please include manual testing steps as well. 

[ ] This change adds unit test coverage (or why not)

[X] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[X] All existing and new tests complete without errors
