### PR TITLE
Removed Carthage Compatible badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Version](https://img.shields.io/cocoapods/v/SimpleKeychain.svg?style=flat-square)](https://cocoapods.org/pods/SimpleKeychain)
 [![License](https://img.shields.io/cocoapods/l/SimpleKeychain.svg?style=flat-square)](https://cocoapods.org/pods/SimpleKeychain)
 [![Platform](https://img.shields.io/cocoapods/p/SimpleKeychain.svg?style=flat-square)](https://cocoapods.org/pods/SimpleKeychain)
-[![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat-square)](https://github.com/Carthage/Carthage)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2FSimpleKeychain.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2FSimpleKeychain?ref=badge_shield)
 
 A wrapper to make it really easy to deal with iOS Keychain and store your user's credentials securely.
@@ -31,7 +30,7 @@ A wrapper to make it really easy to deal with iOS Keychain and store your user's
 ## Requirements
 
 - iOS 9.0+ / macOS 10.11+ / tvOS 9.0+ / watchOS 2.0+
-- Xcode 11.4+ / Xcode 12.x
+- Xcode 11.4+/12.x
 - Swift 4.x/5.x
 
 ## Installation
@@ -158,7 +157,7 @@ If you have found a bug or to request a feature, please [raise an issue](https:/
 
 ## License
 
-This project is licensed under the MIT license. See the [LICENSE](https://github.com/auth0/SimpleKeychain/blob/master/LICENSE) file for more info.
+This project is licensed under the MIT license. See the [LICENSE](LICENSE) file for more info.
 
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fauth0%2FSimpleKeychain.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fauth0%2FSimpleKeychain?ref=badge_large)


### PR DESCRIPTION
### Changes

Having that badge in the README does not really make sense anymore. It was removed from Auth0.swift's README as well.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed