### PR TITLE
Make test dependencies not resolve when installing with SPM [SDK-2598]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.2
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -18,8 +18,8 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
-        .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+        .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [
         .target(


### PR DESCRIPTION
### Changes

SimpleKeychain relies on the [Quick](https://github.com/Quick/Quick) and [Nimble](https://github.com/Quick/Nimble) test libraries for its tests, and it's pinning their version range to a particular major. Currently, when installing SimpleKeychain with the Swift Package Manager it will resolve both test dependencies even though they're not used in the actual library. This opens up the possibility of conflict if the app the libraries are imported into is using another major version of Quick/Nimble.
SPM has, since swift 5.2 (released with Xcode 11.4), supported [a way](https://github.com/apple/swift-evolution/blob/master/proposals/0226-package-manager-target-based-dep-resolution.md) to have the test dependencies not resolve if they're not used. Since we already dropped support for Xcode < 11.4, this will not be a breaking change.

### References

Fixes #107 

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If helpful, please include manual testing steps as well. 

[ ] This change adds unit test coverage (or why not)
[X] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors
