### PR TITLE
Release 0.12.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [0.12.3](https://github.com/auth0/SimpleKeychain/tree/0.12.3) (2021-06-07)
+[Full Changelog](https://github.com/auth0/SimpleKeychain/compare/0.12.2...0.12.3)
+
+**Changed**
+- Make test dependencies not resolve when installing with SPM [SDK-2598] [\#108](https://github.com/auth0/SimpleKeychain/pull/108) ([Widcket](https://github.com/Widcket))
+
 ## [0.12.2](https://github.com/auth0/SimpleKeychain/tree/0.12.2) (2021-02-11)
 [Full Changelog](https://github.com/auth0/SimpleKeychain/compare/0.12.1...0.12.2)
 

--- a/SimpleKeychain/Info.plist
+++ b/SimpleKeychain/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.2</string>
+	<string>0.12.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SimpleKeychainApp/Info.plist
+++ b/SimpleKeychainApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.2</string>
+	<string>0.12.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SimpleKeychainTests/Info.plist
+++ b/SimpleKeychainTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.2</string>
+	<string>0.12.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/tvOSTestHost/Info.plist
+++ b/tvOSTestHost/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.2</string>
+	<string>0.12.3</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
**Changed**
- Make test dependencies not resolve when installing with SPM [SDK-2598] [\#108](https://github.com/auth0/SimpleKeychain/pull/108) ([Widcket](https://github.com/Widcket))


[SDK-2598]: https://auth0team.atlassian.net/browse/SDK-2598