### PR TITLE
Use the new release automation solution

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,7 +39,6 @@ commands:
           paths:
             - vendor/bundle
       - run: |
-          brew install swiftlint
           grep -lR "shouldUseLaunchSchemeArgsEnv" *.* --null | xargs -0 sed -i '' -e 's/shouldUseLaunchSchemeArgsEnv = "YES"/shouldUseLaunchSchemeArgsEnv = "YES" codeCoverageEnabled = "YES"/g'
       - restore_cache:
           keys:

--- a/.shiprc
+++ b/.shiprc
@@ -1,0 +1,7 @@
+{
+    "files": {
+        "SimpleKeychain/Info.plist": []
+    },
+    "postbump": "bundle update",
+    "prefixVersion": false
+}

--- a/SimpleKeychainApp/Info.plist
+++ b/SimpleKeychainApp/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.3</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SimpleKeychainTests/Info.plist
+++ b/SimpleKeychainTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.3</string>
+	<string>0.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,7 +45,7 @@ platform :ios do
     test
   end
 
-  desc "Performs the prepared release by creating a tag and pusing to remote"
+  desc "Performs the prepared release by creating a tag and pushing to remote"
   lane :release_perform do
     perform_release target: 'SimpleKeychain-iOS'
   end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -34,22 +34,24 @@ platform :ios do
       )
   end
 
+  desc "Cocoapods library lint"
+  lane :pod_lint do
+    pod_lib_lint(verbose: false, allow_warnings: true)
+  end
+
   desc "Runs all the tests in a CI environment"
   lane :ci do
     # TODO: Run rest of platforms
     test
   end
 
-  desc "Cocoapods library lint"
-  lane :pod_lint do
-    pod_lib_lint(allow_warnings: true)
+  desc "Performs the prepared release by creating a tag and pusing to remote"
+  lane :release_perform do
+    perform_release target: 'SimpleKeychain-iOS'
   end
 
-  desc "Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG"
-  desc "You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]"
-  lane :release do |options|
-    release_options = {repository: 'SimpleKeychain', xcodeproj: 'SimpleKeychain.xcodeproj'}.merge(options)
-    prepare_release release_options
-    publish_release
+  desc "Releases the library to CocoaPods trunk & Github Releases"
+  lane :release_publish do
+    publish_release repository: 'SimpleKeychain'
   end
 end

--- a/tvOSTestHost/Info.plist
+++ b/tvOSTestHost/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.12.3</string>
+	<string>0.1.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
### Changes

This PR adds support for the new release automation CLI.

Previously, we were using a [custom Fastlane plugin](https://github.com/auth0/fastlane-plugin-auth0_shipper) for bumping the version number and updating the Changelog. To bump the version, that plugin [uses](https://github.com/auth0/fastlane-plugin-auth0_shipper/blob/master/lib/fastlane/plugin/auth0_shipper/actions/prepare_release_action.rb#L24) the `IncrementVersionNumberAction` action from Fastlane. That action [uses](https://github.com/fastlane/fastlane/blob/master/fastlane/lib/fastlane/actions/increment_version_number.rb#L71) the `agvtool new-marketing-version` command to bump the version number. That command will bump the version number in every `Info.plist` file it can find, regardless of whether it's actually necessary or not:

<img width="775" alt="Screen Shot 2021-08-23 at 14 38 22" src="https://user-images.githubusercontent.com/5055789/130507440-fc64aeb9-4e92-4d42-8bcd-165c306302cd.png">

See [a previous release](https://github.com/auth0/SimpleKeychain/pull/109/files) of this SDK:
 
<img width="970" alt="Screen Shot 2021-08-23 at 15 55 28" src="https://user-images.githubusercontent.com/5055789/130502369-87454542-e02f-4eb0-81db-47e62d5cfc9a.png">

It's bumping the version number of the **test app** and the **test targets**, even though it's not necessary; only the **library target's** version number needs to be bumped (`SimpleKeychain/Info.plist`).

So this PR sets up the version number replacement for `SimpleKeychain/Info.plist` in the `.shiprc` file, and sets the version number of the test app and the test targets to be `0.1.0`. That means that going forward, each release PR will only be bumping the version number in `SimpleKeychain/Info.plist`.

Additionally, this PR sets up the post-PR Fastlane tasks, like [the ones in Auth0.swift](https://github.com/auth0/Auth0.swift/blob/master/fastlane/Fastfile#L62-L70), to create the tag and publish to Cocoapods trunk.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors