### PR TITLE
Remove agvtool from podspec

### DIFF
--- a/.shiprc
+++ b/.shiprc
@@ -1,6 +1,7 @@
 {
     "files": {
-        "SimpleKeychain/Info.plist": []
+        "SimpleKeychain/Info.plist": [],
+        "SimpleKeychain.podspec": []
     },
     "postbump": "bundle update",
     "prefixVersion": false

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -1,7 +1,6 @@
-version = `agvtool mvers -terse1`.strip
 Pod::Spec.new do |s|
   s.name             = "SimpleKeychain"
-  s.version          = version
+  s.version          = '0.12.4'
   s.summary          = "A wrapper to make it really easy to deal with iOS Keychain and store your user's credentials securely."
   s.description      = <<-DESC
                        A simple way to store items in iOS Keychain, without the hassle of dealing with iOS Keychain API directly.

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -31,26 +31,29 @@ Bootstrap the development environment
 fastlane ios test
 ```
 Runs all the tests
-### ios ci
-```
-fastlane ios ci
-```
-Runs all the tests in a CI environment
 ### ios pod_lint
 ```
 fastlane ios pod_lint
 ```
 Cocoapods library lint
-### ios release
+### ios ci
 ```
-fastlane ios release
+fastlane ios ci
 ```
-Releases the library to Cocoapods & Github Releases and updates README/CHANGELOG
-
-You need to specify the type of release with the `bump` parameter with the values [major|minor|patch]
+Runs all the tests in a CI environment
+### ios release_perform
+```
+fastlane ios release_perform
+```
+Performs the prepared release by creating a tag and pushing to remote
+### ios release_publish
+```
+fastlane ios release_publish
+```
+Releases the library to CocoaPods trunk & Github Releases
 
 ----
 
-This README.md is auto-generated and will be re-generated every time [fastlane](https://fastlane.tools) is run.
+This README.md is auto-generated and will be re-generated every time [_fastlane_](https://fastlane.tools) is run.
 More information about fastlane can be found on [fastlane.tools](https://fastlane.tools).
 The documentation of fastlane can be found on [docs.fastlane.tools](https://docs.fastlane.tools).


### PR DESCRIPTION
### Changes

The podspec relied on `agvtool` to get the current version number. That tool looks up the relevant key in every `Info.plist` file it can find:

<img width="764" alt="Screen Shot 2021-09-01 at 16 33 38" src="https://user-images.githubusercontent.com/5055789/131732752-b300f8f4-359c-4c2f-a8c8-cac89ee99c38.png">

This PR does away with `agvtool` and just uses the release CLI to bump the version number in the podspec. 

### References

Related to https://github.com/auth0/SimpleKeychain/pull/112

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed