### PR TITLE
Updated dependencies

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Cartfile.private
+++ b/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" ~> 3.0
+github "Quick/Quick" ~> 4.0
 github "Quick/Nimble" ~> 9.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v9.0.0"
-github "Quick/Quick" "v3.1.2"
+github "Quick/Nimble" "v9.2.1"
+github "Quick/Quick" "v4.0.0"

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "3.0.0")),
+        .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.0.0"))
     ],
     targets: [

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -296,7 +296,7 @@
         case errSecDecode:
             return NSLocalizedStringFromTable(@"errSecDecode: Unable to decode the provided data", @"SimpleKeychain", @"Possible error from keychain. ");
         default:
-            return [NSString stringWithFormat:NSLocalizedStringFromTable(@"Unknown error code %d", @"SimpleKeychain", @"Possible error from keychain. "), status];
+            return [NSString stringWithFormat:NSLocalizedStringFromTable(@"Unknown error code %d", @"SimpleKeychain", @"Possible error from keychain. "), (int)status];
     }
 }
 


### PR DESCRIPTION
### Changes

This PR updates [Quick](https://github.com/Quick/Quick) to version [4.0.0](https://github.com/Quick/Quick/releases/tag/v4.0.0), and fixes a Xcode 13 warning.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [ ] All existing and new tests complete without errors
* [ ] All active GitHub checks have passed