### PR TITLE
Added keys method

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -323,6 +323,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (BOOL)hasValueForKey:(NSString *)key;
 
+
+/**
+ *  Fetches an array of NSString containing all the keys used in the keychain
+ *
+ *  @return a NSString array with all keys from the keychain.
+ */
+- (nonnull NSArray *)keys;
+
 ///---------------------------------------------------
 /// @name Create helper methods
 ///---------------------------------------------------

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -120,6 +120,27 @@
     return status == errSecSuccess;
 }
 
+- (nonnull NSArray *)keys {
+    
+    NSMutableArray *keys = [NSMutableArray array];
+    NSDictionary *query = [self queryFindAll];
+    CFArrayRef result = nil;
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    if (status == errSecSuccess || status == errSecItemNotFound) {
+        NSArray *items = [NSArray arrayWithArray:(__bridge NSArray *)result];
+        CFBridgingRelease(result);
+        for (NSDictionary *item in items) {
+            id secAccount = item[(__bridge id)kSecAttrAccount];
+            if ([secAccount isKindOfClass:[NSString class]]) {
+                NSString *key = (NSString *)secAccount;
+                [keys addObject:key];
+            }
+        }
+    }
+    return keys;
+}
+
+
 - (BOOL)setString:(NSString *)string forKey:(NSString *)key {
     return [self setString:string forKey:key promptMessage:nil];
 }

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -168,6 +168,48 @@ class A0SimpleKeychainSpec: QuickSpec {
                     expect(keychain.data(forKey: key)).notTo(beNil())
                 }
             }
+            
+            describe("retrieving keys") {
+                
+                var keys = [String]()
+                
+                beforeEach {
+                    
+                    keychain.clearAll()
+                    
+                    keychain = A0SimpleKeychain(service: kKeychainService)
+                    keys.append(NSUUID().uuidString)
+                    keys.append(NSUUID().uuidString)
+                    keys.append(NSUUID().uuidString)
+                    for (i, key) in keys.enumerated() {
+                        keychain.setString("value\(i)", forKey: key)
+                    }
+                }
+                
+                afterEach {
+                    keychain.clearAll()
+                }
+                
+                it("should return all the keys") {
+                    expect(keychain.keys() as? [String]).to(equal(keys))
+                }
+                
+                it("should clear all") {
+                    
+                    for key in keys {
+                        expect(keychain.data(forKey: key)).notTo(beNil())
+                    }
+                    expect(keychain.keys().count).to(equal(keys.count))
+                    
+                    keychain.clearAll()
+                    
+                    for key in keys {
+                        expect(keychain.data(forKey: key)).to(beNil())
+                    }
+                    expect(keychain.keys().count).to(equal(0))
+                }
+            }
+
 
             describe("generate key pair") {
 


### PR DESCRIPTION
Returns an array of NSString containing all the keys used in the keychain

### Changes

I added a method named `keys` to retieve all the keys used by the app in the keychain. This can be useful when you want to delete only the keys with a common pattern, for example keys containing the same account name with different prefixes or suffixes.

### Testing

I added a couple of tests.
