### PR TITLE
Drop old platform versions [SDK-3387]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,18 +5,8 @@ import PackageDescription
 
 let package = Package(
     name: "SimpleKeychain",
-    platforms: [
-        .iOS(.v9),
-        .macOS(.v10_11),
-        .watchOS(.v2),
-        .tvOS(.v9)
-    ],
-    products: [
-        .library(
-            name: "SimpleKeychain",
-            targets: ["SimpleKeychain"]
-        )
-    ],
+    platforms: [.iOS(.v12), .macOS(.v10_15), .tvOS(.v12), .watchOS("6.2")],
+    products: [.library(name: "SimpleKeychain", targets: ["SimpleKeychain"])],
     dependencies: [
         .package(name: "Quick", url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "5.0.0")),
         .package(name: "Nimble", url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "10.0.0"))

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -12,12 +12,12 @@ Pod::Spec.new do |s|
   s.source           = { :git => "https://github.com/auth0/SimpleKeychain.git", :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/auth0'
 
-  s.ios.deployment_target = '9.0'
-  s.osx.deployment_target = '10.11'
-  s.watchos.deployment_target = '2.0'
-  s.tvos.deployment_target = '9.0'
+  s.ios.deployment_target = '12.0'
+  s.osx.deployment_target = '10.15'
+  s.tvos.deployment_target = '12.0'
+  s.watchos.deployment_target = '6.2'
   s.requires_arc = true
+
   s.source_files = 'SimpleKeychain/*.{h,m}'
   s.exclude_files = 'SimpleKeychain/include/*'
-
 end

--- a/SimpleKeychain.xcodeproj/project.pbxproj
+++ b/SimpleKeychain.xcodeproj/project.pbxproj
@@ -872,7 +872,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tvOSTestHost.app/tvOSTestHost";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -896,7 +896,7 @@
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/tvOSTestHost.app/tvOSTestHost";
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -923,13 +923,12 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SimpleKeychain;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Debug;
 		};
@@ -951,13 +950,12 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SimpleKeychain;
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.2;
 			};
 			name = Release;
 		};
@@ -985,7 +983,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -1013,7 +1011,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 9.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -1045,7 +1043,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 13.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -1073,7 +1071,7 @@
 				SDKROOT = appletvos;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 13.2;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
@@ -1084,7 +1082,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				INFOPLIST_FILE = SimpleKeychainTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1104,7 +1102,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				INFOPLIST_FILE = SimpleKeychainTests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1128,7 +1126,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.SimpleKeychainTests;
 				PRODUCT_NAME = SimpleKeychainTests;
 				SDKROOT = macosx;
@@ -1147,7 +1145,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = com.auth0.SimpleKeychainTests;
 				PRODUCT_NAME = SimpleKeychainTests;
 				SDKROOT = macosx;
@@ -1166,6 +1164,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_FILE = SimpleKeychainApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1185,6 +1184,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SimpleKeychainApp/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1324,6 +1324,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SimpleKeychain/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1346,6 +1347,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = SimpleKeychain/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1379,7 +1381,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SimpleKeychain;
 				SDKROOT = macosx;
@@ -1404,7 +1406,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.15;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.auth0.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = SimpleKeychain;
 				SDKROOT = macosx;

--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -11,7 +11,7 @@
 ///---------------------------------------------------
 
 /**
- *  Enum with Kechain items accessibility types. It's a mirror of `kSecAttrAccessible` values.
+ *  Enum with Keychain items accessibility types. It's a mirror of `kSecAttrAccessible` values.
  */
 typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
     /**
@@ -46,8 +46,7 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
 
 #define A0ErrorDomain @"com.auth0.simplekeychain"
 
-#define A0LocalAuthenticationCapable (TARGET_OS_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= 80000) || (TARGET_OS_OSX && __MAC_OS_X_VERSION_MIN_REQUIRED >= MAC_OS_X_VERSION_10_2)
-
+#define A0LocalAuthenticationCapable TARGET_OS_IOS || TARGET_OS_OSX
 
 /**
  * Enum with keychain error codes. It's a mirror of the keychain error codes. 
@@ -99,9 +98,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  A simple helper class to deal with storing and retrieving values from iOS Keychain.
- *  It has support for sharing keychain items using Access Group and also for iOS 8 fine grained accesibility over a specific Kyechain Item (Using Access Control).
- *  The support is only available for iOS 8+, otherwise it will default using the coarse grained accesibility field.
- *  When a `NSString` or `NSData` is stored using Access Control and the accesibility flag `A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly`, iOS will prompt the user for it's passcode or pass a TouchID challenge (if available).
+ *  It has support for sharing Keychain items using Access Group and also for fine grained accessibility over a specific Keychain Item (Using Access Control).
+ *  When a `NSString` or `NSData` is stored using Access Control and the accessibility flag `A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly`, the OS will prompt the user for their passcode or present a biometrics challenge (if available).
  */
 @interface A0SimpleKeychain : NSObject
 
@@ -123,7 +121,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (assign, nonatomic) A0SimpleKeychainItemAccessible defaultAccessiblity;
 
 /**
- *  Tells A0SimpleKeychain to use `kSecAttrAccessControl` instead of `kSecAttrAccessible`. It will work only in iOS 8+, defaulting to `kSecAttrAccessible` on lower version.
+ *  Tells A0SimpleKeychain to use `kSecAttrAccessControl` instead of `kSecAttrAccessible`.
  *  Default value is NO.
  */
 @property (assign, nonatomic) BOOL useAccessControl;
@@ -141,37 +139,37 @@ NS_ASSUME_NONNULL_BEGIN
 ///---------------------------------------------------
 
 /**
- *  Initialise a `A0SimpleKeychain` with default values.
+ *  Initialize a `A0SimpleKeychain` with default values.
  *
  *  @return an initialised instance
  */
 - (instancetype)init;
 
 /**
- *  Initialise a `A0SimpleKeychain` with a given service.
+ *  Initialize a `A0SimpleKeychain` with a given service.
  *
  *  @param service name of the service to use to save items.
  *
- *  @return an initialised instance.
+ *  @return an initialized instance.
  */
 - (instancetype)initWithService:(NSString *)service;
 
 /**
- *  Initialise a `A0SimpleKeychain` with a given service and access group.
+ *  Initialize a `A0SimpleKeychain` with a given service and access group.
  *
  *  @param service name of the service to use to save items.
  *  @param accessGroup name of the access group to share items.
  *
- *  @return an initialised instance.
+ *  @return an initialized instance.
  */
 - (instancetype)initWithService:(NSString *)service accessGroup:(nullable NSString *)accessGroup;
 
 /**
  *  The duration for which Touch ID authentication reuse is allowable.
- *  Maximun value is LATouchIDAuthenticationMaximumAllowableReuseDuration
+ *  Maximum value is LATouchIDAuthenticationMaximumAllowableReuseDuration
  */
 #if A0LocalAuthenticationCapable
-- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration API_AVAILABLE(ios(8), macosx(10.12)) API_UNAVAILABLE(watchos, tvos);
+- (void)setTouchIDAuthenticationAllowableReuseDuration:(NSTimeInterval) duration API_UNAVAILABLE(watchos, tvos);
 #endif
 
 ///---------------------------------------------------
@@ -203,7 +201,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param string   value to save in the keychain
  *  @param key      key for the keychain entry.
- *  @param message  prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param message  prompt message to display for TouchID/passcode prompt if necessary
  *
  *  @return if the value was saved it will return YES. Otherwise it'll return NO.
  */
@@ -214,7 +212,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @param data   value to save in the keychain
  *  @param key      key for the keychain entry.
- *  @param message  prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param message  prompt message to display for TouchID/passcode prompt if necessary
  *
  *  @return if the value was saved it will return YES. Otherwise it'll return NO.
  */
@@ -234,7 +232,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)deleteEntryForKey:(NSString *)key;
 
 /**
- *  Remove all entries from the kechain with the service and access group values.
+ *  Remove all entries from the Keychain with the service and access group values.
  */
 - (void)clearAll;
 
@@ -243,7 +241,7 @@ NS_ASSUME_NONNULL_BEGIN
 ///---------------------------------------------------
 
 /**
- *  Fetches a NSString from the keychain
+ *  Fetches a NSString from the Keychain
  *
  *  @param key the key of the value to fetch
  *
@@ -252,7 +250,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString *)stringForKey:(NSString *)key;
 
 /**
- *  Fetches a NSData from the keychain
+ *  Fetches a NSData from the Keychain
  *
  *  @param key the key of the value to fetch
  *
@@ -261,30 +259,30 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)dataForKey:(NSString *)key;
 
 /**
- *  Fetches a NSString from the keychain
+ *  Fetches a NSString from the Keychain
  *
  *  @param key     the key of the value to fetch
- *  @param message prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param message prompt message to display for TouchID/passcode prompt if necessary
  *
  *  @return the value or nil if an error occurs.
  */
 - (nullable NSString *)stringForKey:(NSString *)key promptMessage:(nullable NSString *)message;
 
 /**
- *  Fetches a NSData from the keychain
+ *  Fetches a NSData from the Keychain
  *
  *  @param key     the key of the value to fetch
- *  @param message prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param message prompt message to display for TouchID/passcode prompt if necessary
  *
  *  @return the value or nil if an error occurs.
  */
 - (nullable NSData *)dataForKey:(NSString *)key promptMessage:(nullable NSString *)message;
 
 /**
- *  Fetches a NSData from the keychain
+ *  Fetches a NSData from the Keychain
  *
  *  @param key     the key of the value to fetch
- *  @param message prompt message to display for TouchID/passcode prompt if neccesary
+ *  @param message prompt message to display for TouchID/passcode prompt if necessary
  *  @param err     Returns an error, if the item cannot be retrieved. F.e. item not found 
  *                 or user authentication failed in TouchId case.
  *
@@ -303,9 +301,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
- *  Fetches an array of NSString containing all the keys used in the keychain
+ *  Fetches an array of NSString containing all the keys used in the Keychain
  *
- *  @return a NSString array with all keys from the keychain.
+ *  @return a NSString array with all keys from the Keychain.
  */
 - (nonnull NSArray *)keys;
 
@@ -333,7 +331,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Creates a new instance of `A0SimpleKeychain` with a service name and access group
  *
  *  @param service     name of the service under all items will be stored.
- *  @param accessGroup name of the access group to share keychain items.
+ *  @param accessGroup name of the access group to share Keychain items.
  *
  *  @return a new instance
  */

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -138,6 +138,20 @@
     
     NSDictionary *query = [self queryFindByKey:key message:message];
 
+    // Touch ID case
+    if (self.useAccessControl && self.defaultAccessiblity == A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly) {
+        // TouchId case. Doesn't support updating keychain items
+        // see Known Issues: https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-8.0/
+        // We need to delete old and add a new item. This can fail
+        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
+        if (status == errSecSuccess || status == errSecItemNotFound) {
+            NSDictionary *newQuery = [self queryNewKey:key value:data];
+            OSStatus status = SecItemAdd((__bridge CFDictionaryRef)newQuery, NULL);
+            return status == errSecSuccess;
+        }
+    }
+
+    // Normal case
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
     if (status == errSecSuccess) {
         if (data) {

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -352,10 +352,8 @@
                                       (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
                                       (__bridge id)kSecAttrAccount: key,
                                       }];
-    if (self.useAccessControl) {
-        if (message) {
-            query[(__bridge id)kSecUseOperationPrompt] = message;
-        }
+    if (self.useAccessControl && message) {
+        query[(__bridge id)kSecUseOperationPrompt] = message;
     }
 
     return query;

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -347,4 +347,3 @@
     return query;
 }
 @end
-

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -213,10 +213,8 @@
             accessibility = kSecAttrAccessibleAlwaysThisDeviceOnly;
 #endif
             break;
-#if TARGET_OS_IPHONE
         case A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly:
             accessibility = kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
-#endif
             break;
         case A0SimpleKeychainItemAccessibleWhenUnlocked:
             accessibility = kSecAttrAccessibleWhenUnlocked;

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -318,7 +318,6 @@
     NSMutableDictionary *query = [self baseQuery];
     query[(__bridge id)kSecAttrAccount] = key;
     query[(__bridge id)kSecValueData] = value;
-#if TARGET_OS_IOS || TARGET_OS_OSX
     if (self.useAccessControl) {
         CFErrorRef error = NULL;
         SecAccessControlRef accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault, [self accessibility], kSecAccessControlUserPresence, &error);
@@ -329,9 +328,6 @@
     } else {
         query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
     }
-#else
-    query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
-#endif
     return query;
 }
 
@@ -342,14 +338,13 @@
                                       (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
                                       (__bridge id)kSecAttrAccount: key,
                                       }];
-#if TARGET_OS_IOS || TARGET_OS_OSX
     if (self.useAccessControl) {
         if (message) {
             query[(__bridge id)kSecUseOperationPrompt] = message;
         }
     }
-#endif
 
     return query;
 }
 @end
+

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -329,6 +329,8 @@
     } else {
         query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
     }
+#else
+    query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
 #endif
     return query;
 }

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -137,21 +137,7 @@
     }
     
     NSDictionary *query = [self queryFindByKey:key message:message];
-    
-    // Touch ID case
-    if (self.useAccessControl && self.defaultAccessiblity == A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly) {
-        // TouchId case. Doesn't support updating keychain items
-        // see Known Issues: https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-8.0/
-        // We need to delete old and add a new item. This can fail
-        OSStatus status = SecItemDelete((__bridge CFDictionaryRef)query);
-        if (status == errSecSuccess || status == errSecItemNotFound) {
-            NSDictionary *newQuery = [self queryNewKey:key value:data];
-            OSStatus status = SecItemAdd((__bridge CFDictionaryRef)newQuery, NULL);
-            return status == errSecSuccess;
-        }
-    }
-    
-    // Normal case
+
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, NULL);
     if (status == errSecSuccess) {
         if (data) {
@@ -179,32 +165,15 @@
 }
 
 - (void)clearAll {
-#if TARGET_OS_IPHONE
-  NSDictionary *query = [self queryFindAll];
-  CFArrayRef result = nil;
-  OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
-  if (status == errSecSuccess || status == errSecItemNotFound) {
-    NSArray *items = [NSArray arrayWithArray:(__bridge NSArray *)result];
-    CFBridgingRelease(result);
-    for (NSDictionary *item in items) {
-      NSMutableDictionary *queryDelete = [[NSMutableDictionary alloc] initWithDictionary:item];
-      queryDelete[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
-
-      OSStatus status = SecItemDelete((__bridge CFDictionaryRef)queryDelete);
-      if (status != errSecSuccess) {
-        break;
-      }
-    }
-  }
-#else
   NSMutableDictionary *queryDelete = [self baseQuery];
   queryDelete[(__bridge id)kSecClass] = (__bridge id)kSecClassGenericPassword;
+#if !TARGET_OS_IPHONE
   queryDelete[(__bridge id)kSecMatchLimit] = (__bridge id)kSecMatchLimitAll;
+#endif
   OSStatus status = SecItemDelete((__bridge CFDictionaryRef)queryDelete);
   if (status != errSecSuccess) {
     return;
   }
-#endif
 }
 
 + (A0SimpleKeychain *)keychain {
@@ -246,15 +215,7 @@
             break;
 #if TARGET_OS_IPHONE
         case A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly:
-#ifdef __IPHONE_8_0
-            if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) { //iOS 8
-                accessibility = kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
-            } else { //iOS <= 7.1
-                accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
-            }
-#else
-            accessibility = kSecAttrAccessibleWhenUnlockedThisDeviceOnly;
-#endif
+            accessibility = kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
 #endif
             break;
         case A0SimpleKeychainItemAccessibleWhenUnlocked:
@@ -359,28 +320,17 @@
     NSMutableDictionary *query = [self baseQuery];
     query[(__bridge id)kSecAttrAccount] = key;
     query[(__bridge id)kSecValueData] = value;
-#if TARGET_OS_IPHONE
-#ifdef __IPHONE_8_0
-    if (self.useAccessControl && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {
+#if TARGET_OS_IOS || TARGET_OS_OSX
+    if (self.useAccessControl) {
         CFErrorRef error = NULL;
         SecAccessControlRef accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault, [self accessibility], kSecAccessControlUserPresence, &error);
         if (error == NULL || accessControl != NULL) {
             query[(__bridge id)kSecAttrAccessControl] = (__bridge_transfer id)accessControl;
-#if defined __MAC_10_12 || defined __IPHONE_11_0
-            // This also applies to watchOS & tvOS
-            if (@available(iOS 9, *)) {
-                query[(__bridge id)kSecUseAuthenticationUI] = (__bridge_transfer id)kSecUseAuthenticationUIFail;
-            }
-#else
-            query[(__bridge id)kSecUseNoAuthenticationUI] = @YES;
-#endif
+            query[(__bridge id)kSecUseAuthenticationUI] = (__bridge_transfer id)kSecUseAuthenticationUIFail;
         }
     } else {
         query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
     }
-#else
-    query[(__bridge id)kSecAttrAccessible] = (__bridge id)[self accessibility];
-#endif
 #endif
     return query;
 }
@@ -392,9 +342,9 @@
                                       (__bridge id)kSecMatchLimit: (__bridge id)kSecMatchLimitOne,
                                       (__bridge id)kSecAttrAccount: key,
                                       }];
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS || TARGET_OS_OSX
     if (self.useAccessControl) {
-        if (message && floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_7_1) {
+        if (message) {
             query[(__bridge id)kSecUseOperationPrompt] = message;
         }
     }

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -4,8 +4,19 @@ As expected with a major release, SimpleKeychain v1 contains breaking changes. P
 
 ## Table of Contents
 
+- [**Supported Languages**](#supported-languages)
+- [**Supported Platform Versions**](#supported-platform-versions)
+- [**Methods Removed**](#methods-removed)
+
 ## Supported Languages
 
 ## Supported Platform Versions
+
+The deployment targets for each platform were raised to:
+
+- iOS **12.0**
+- macOS **10.15**
+- tvOS **12.0**
+- watchOS **6.2**
 
 ## Methods Removed


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR raises the deployment targets to:

- iOS **12.0**
- macOS **10.15**
- tvOS **12.0**
- watchOS **6.2**

Also preprocessor macros regarding older platform versions were removed, as well as some blocks of code that worked around limitations on those older versions.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed