### PR TITLE
Remove deprecated method [SDK-3413]

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain+KeyPair.h
+++ b/SimpleKeychain/A0SimpleKeychain+KeyPair.h
@@ -65,19 +65,4 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface A0SimpleKeychain (Deprecated)
-
-/**
- *  Returns the public key as NSData.
- *
- *  @param keyTag tag of the public key
- *
- *  @return the public key as NSData or nil if not found
- *  
- *  @deprecated 0.2.0
- */
-- (nullable NSData *)publicRSAKeyDataForTag:(NSString *)keyTag __attribute__((deprecated));
-
-@end
-
 NS_ASSUME_NONNULL_END

--- a/SimpleKeychain/A0SimpleKeychain+KeyPair.m
+++ b/SimpleKeychain/A0SimpleKeychain+KeyPair.m
@@ -101,11 +101,3 @@
 }
 
 @end
-
-@implementation A0SimpleKeychain (Deprecated)
-
-- (NSData *)publicRSAKeyDataForTag:(NSString *)keyTag {
-    return [self dataForRSAKeyWithTag:keyTag];
-}
-
-@end

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -20,3 +20,5 @@ The deployment targets for each platform were raised to:
 - watchOS **6.2**
 
 ## Methods Removed
+
+The method `publicRSAKeyData(forTag:)` was removed.


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR removes the deprecated method `publicRSAKeyData(forTag:)`.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[X] All existing and new tests complete without errors
