### PR TITLE
Remove usage of deprecated properties [SDK-3414]

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -23,10 +23,6 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
      */
     A0SimpleKeychainItemAccessibleAfterFirstUnlock,
     /**
-     *  @see kSecAttrAccessibleAlways
-     */
-    A0SimpleKeychainItemAccessibleAlways,
-    /**
      *  @see kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly
      */
     A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly,
@@ -37,11 +33,7 @@ typedef NS_ENUM(NSInteger, A0SimpleKeychainItemAccessible) {
     /**
      *  kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
      */
-    A0SimpleKeychainItemAccessibleAfterFirstUnlockThisDeviceOnly,
-    /**
-     *  @see kSecAttrAccessibleAlwaysThisDeviceOnly
-     */
-    A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly
+    A0SimpleKeychainItemAccessibleAfterFirstUnlockThisDeviceOnly
 };
 
 #define A0ErrorDomain @"com.auth0.simplekeychain"

--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -128,7 +128,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 
 /**
-*  LocalAuthenticationContext used to access items. Default value is a new LAContext object
+*  Local Authentication context used to access items. Default value is a new `LAContext` object.
 */
 #if A0LocalAuthenticationCapable
 @property (readonly, nullable, nonatomic) LAContext *localAuthenticationContext;
@@ -141,7 +141,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  Initialize a `A0SimpleKeychain` with default values.
  *
- *  @return an initialised instance
+ *  @return an initialized instance
  */
 - (instancetype)init;
 

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -211,21 +211,13 @@
             accessibility = kSecAttrAccessibleAfterFirstUnlock;
             break;
         case A0SimpleKeychainItemAccessibleAlways:
-#if TARGET_OS_MACCATALYST
             accessibility = kSecAttrAccessibleAfterFirstUnlock;
-#else
-            accessibility = kSecAttrAccessibleAlways;
-#endif
             break;
         case A0SimpleKeychainItemAccessibleAfterFirstUnlockThisDeviceOnly:
             accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
             break;
         case A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly:
-#if TARGET_OS_MACCATALYST
             accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
-#else
-            accessibility = kSecAttrAccessibleAlwaysThisDeviceOnly;
-#endif
             break;
         case A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly:
             accessibility = kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly;
@@ -276,7 +268,6 @@
     NSMutableDictionary *attributes = [@{
                                          (__bridge id)kSecClass: (__bridge id)kSecClassGenericPassword,
                                          (__bridge id)kSecAttrService: self.service,
-                                         (__bridge id)kSecUseAuthenticationUI: (__bridge id)kSecUseAuthenticationUIAllow,
                                          } mutableCopy];
 
 #if !TARGET_IPHONE_SIMULATOR
@@ -305,27 +296,20 @@
     NSAssert(key != nil, @"Must have a valid non-nil key");
     NSMutableDictionary *query = [self baseQuery];
     query[(__bridge id)kSecAttrAccount] = key;
-#if TARGET_OS_IPHONE
     if (message) {
         query[(__bridge id)kSecUseOperationPrompt] = message;
     }
-#endif
     return query;
 }
 
 - (NSDictionary *)queryUpdateValue:(NSData *)data message:(NSString *)message {
     if (message) {
         return @{
-#if TARGET_OS_IPHONE
-                 (__bridge id)kSecUseOperationPrompt: message,
-#endif
-                 (__bridge id)kSecValueData: data,
-                 };
-    } else {
-        return @{
-                 (__bridge id)kSecValueData: data,
-                 };
+            (__bridge id)kSecUseOperationPrompt: message,
+            (__bridge id)kSecValueData: data
+        };
     }
+    return @{(__bridge id)kSecValueData: data};
 }
 
 - (NSDictionary *)queryNewKey:(NSString *)key value:(NSData *)value {

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -210,13 +210,7 @@
         case A0SimpleKeychainItemAccessibleAfterFirstUnlock:
             accessibility = kSecAttrAccessibleAfterFirstUnlock;
             break;
-        case A0SimpleKeychainItemAccessibleAlways:
-            accessibility = kSecAttrAccessibleAfterFirstUnlock;
-            break;
         case A0SimpleKeychainItemAccessibleAfterFirstUnlockThisDeviceOnly:
-            accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
-            break;
-        case A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly:
             accessibility = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
             break;
         case A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly:

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -19,4 +19,11 @@ The deployment targets for each platform were raised to:
 - tvOS **12.0**
 - watchOS **6.2**
 
+## Enum Cases Removed
+
+The following cases were rmoved from the `A0SimpleKeychainItemAccessible` enum:
+
+- `A0SimpleKeychainItemAccessibleAlways`
+- `A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly`
+
 ## Methods Removed

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -21,7 +21,7 @@ The deployment targets for each platform were raised to:
 
 ## Enum Cases Removed
 
-The following cases were rmoved from the `A0SimpleKeychainItemAccessible` enum:
+The following cases were removed from the `A0SimpleKeychainItemAccessible` enum:
 
 - `A0SimpleKeychainItemAccessibleAlways`
 - `A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly`


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR removes the usage of the following deprecated iOS/macOS/tvOS/watchOS properties:
- `kSecAttrAccessibleAlways`: https://developer.apple.com/documentation/security/ksecattraccessiblealways
- `kSecAttrAccessibleAlwaysThisDeviceOnly`: https://developer.apple.com/documentation/security/ksecattraccessiblealwaysthisdeviceonly

This results in the removal of the following cases of the `A0SimpleKeychainItemAccessible` enum:

- `A0SimpleKeychainItemAccessibleAlways`
- `A0SimpleKeychainItemAccessibleAlwaysThisDeviceOnly`

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[X] All existing and new tests complete without errors
