### PR TITLE
Fix typo in property name

### DIFF
--- a/SimpleKeychain/A0SimpleKeychain.h
+++ b/SimpleKeychain/A0SimpleKeychain.h
@@ -110,7 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Default value is A0SimpleKeychainItemAccessibleAfterFirstUnlock.
  *  @see kSecAttrAccessible
  */
-@property (assign, nonatomic) A0SimpleKeychainItemAccessible defaultAccessiblity;
+@property (assign, nonatomic) A0SimpleKeychainItemAccessible defaultAccessibility;
 
 /**
  *  Tells A0SimpleKeychain to use `kSecAttrAccessControl` instead of `kSecAttrAccessible`.

--- a/SimpleKeychain/A0SimpleKeychain.m
+++ b/SimpleKeychain/A0SimpleKeychain.m
@@ -20,7 +20,7 @@
     if (self) {
         _service = service;
         _accessGroup = accessGroup;
-        _defaultAccessiblity = A0SimpleKeychainItemAccessibleAfterFirstUnlock;
+        _defaultAccessibility = A0SimpleKeychainItemAccessibleAfterFirstUnlock;
         _useAccessControl = NO;
         
 // This does not apply to watchOS & tvOS
@@ -139,7 +139,7 @@
     NSDictionary *query = [self queryFindByKey:key message:message];
 
     // Touch ID case
-    if (self.useAccessControl && self.defaultAccessiblity == A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly) {
+    if (self.useAccessControl && self.defaultAccessibility == A0SimpleKeychainItemAccessibleWhenPasscodeSetThisDeviceOnly) {
         // TouchId case. Doesn't support updating keychain items
         // see Known Issues: https://developer.apple.com/library/ios/releasenotes/General/RN-iOSSDK-8.0/
         // We need to delete old and add a new item. This can fail
@@ -206,7 +206,7 @@
 
 - (CFTypeRef)accessibility {
     CFTypeRef accessibility;
-    switch (self.defaultAccessiblity) {
+    switch (self.defaultAccessibility) {
         case A0SimpleKeychainItemAccessibleAfterFirstUnlock:
             accessibility = kSecAttrAccessibleAfterFirstUnlock;
             break;

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -16,7 +16,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                 it("should init with default values") {
                     keychain = A0SimpleKeychain()
                     expect(keychain.accessGroup).to(beNil())
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
 
@@ -24,7 +24,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                     keychain = A0SimpleKeychain(service: kKeychainService)
                     expect(keychain.accessGroup).to(beNil())
                     expect(keychain.service).to(equal(kKeychainService))
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
 
@@ -32,7 +32,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                     keychain = A0SimpleKeychain(service: kKeychainService, accessGroup: "Group")
                     expect(keychain.accessGroup).to(equal("Group"))
                     expect(keychain.service).to(equal(kKeychainService))
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
             }
@@ -41,7 +41,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                 it("should create with default values") {
                     keychain = A0SimpleKeychain()
                     expect(keychain.accessGroup).to(beNil())
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
 
@@ -49,7 +49,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                     keychain = A0SimpleKeychain(service: kKeychainService)
                     expect(keychain.accessGroup).to(beNil())
                     expect(keychain.service).to(equal(kKeychainService))
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
 
@@ -57,7 +57,7 @@ class A0SimpleKeychainSpec: QuickSpec {
                     keychain = A0SimpleKeychain(service: kKeychainService, accessGroup: "Group")
                     expect(keychain.accessGroup).to(equal("Group"))
                     expect(keychain.service).to(equal(kKeychainService))
-                    expect(keychain.defaultAccessiblity).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
+                    expect(keychain.defaultAccessibility).to(equal(A0SimpleKeychainItemAccessible.afterFirstUnlock))
                     expect(keychain.useAccessControl).to(beFalsy())
                 }
             }

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -19,6 +19,10 @@ The deployment targets for each platform were raised to:
 - tvOS **12.0**
 - watchOS **6.2**
 
+## Properties Changed
+
+The `defaultAccessiblity` property was renamed to `defaultAccessibility`.
+
 ## Enum Cases Removed
 
 The following cases were removed from the `A0SimpleKeychainItemAccessible` enum:


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

This PR renames the `defaultAccessiblity` property to `defaultAccessibility`.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[X] All existing and new tests complete without errors