### PR TITLE
Drop support for old Swift versions [SDK-3444]

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
@@ -15,12 +15,12 @@ let package = Package(
         .target(
             name: "SimpleKeychain",
             dependencies: [],
-            path: "SimpleKeychain"
-        ),
+            path: "SimpleKeychain",
+            exclude: ["Info.plist"]),
         .testTarget(
             name: "SimpleKeychainTests",
             dependencies: ["SimpleKeychain", "Quick", "Nimble"],
-            path: "SimpleKeychainTests"
-        )
+            path: "SimpleKeychainTests",
+            exclude: ["Info.plist"])
     ]
 )

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -1,15 +1,15 @@
 Pod::Spec.new do |s|
-  s.name             = "SimpleKeychain"
+  s.name             = 'SimpleKeychain'
   s.version          = '0.12.5'
-  s.summary          = "A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS"
+  s.summary          = 'A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                        Easily store your user's credentials in the Keychain.
                        Supports sharing credentials with an Access Group and integrating Touch ID / Face ID through a LAContext instance.
                        DESC
-  s.homepage         = "https://github.com/auth0/SimpleKeychain"
+  s.homepage         = 'https://github.com/auth0/SimpleKeychain'
   s.license          = 'MIT'
-  s.author           = { "Auth0" => "support@auth0.com", "Hernan Zalazar" => "hernan@auth0.com" }
-  s.source           = { :git => "https://github.com/auth0/SimpleKeychain.git", :tag => s.version.to_s }
+  s.author           = { 'Auth0' => 'support@auth0.com', 'Rita Zerrizuela' => 'rita.zerrizuela@auth0.com' }
+  s.source           = { :git => 'https://github.com/auth0/SimpleKeychain.git', :tag => s.version.to_s }
   s.social_media_url = 'https://twitter.com/auth0'
 
   s.ios.deployment_target = '12.0'
@@ -18,4 +18,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '6.2'
 
   s.source_files = 'SimpleKeychain/*.swift'
+  s.swift_versions = ['5.5', '5.6']
 end

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -7,6 +7,7 @@ As expected with a major release, SimpleKeychain v1 contains breaking changes. P
 ## Table of Contents
 
 - [**Supported Languages**](#supported-languages)
+  + [Swift](#swift)
   + [Objective-C](#objective-c)
 - [**Supported Platform Versions**](#supported-platform-versions)
 - [**Types Removed**](#types-removed)
@@ -21,6 +22,10 @@ As expected with a major release, SimpleKeychain v1 contains breaking changes. P
   + [SimpleKeychain Struct](#simplekeychain-struct-3)
 
 ## Supported Languages
+
+### Swift
+
+The minimum supported Swift version is now **5.5**.
 
 ### Objective-C
 
@@ -65,7 +70,7 @@ The following properties are no longer public:
 
 ### SimpleKeychain Struct
 
-The `setTouchIDAuthenticationAllowableReuseDuration` method was removed. Configure that in a custom `LAContext` instance instead.
+The `setTouchIDAuthenticationAllowableReuseDuration(_:)` method was removed. Configure that in a custom `LAContext` instance instead.
 
 <!-- BEFORE/AFTER -->
 


### PR DESCRIPTION
### Changes

⚠️ **THIS PR CONTAINS BREAKING CHANGES**

The minimum Swift version supported was raised to 5.5.

### References

<img width="732" alt="Screen Shot 2022-06-01 at 21 58 09" src="https://user-images.githubusercontent.com/5055789/171525365-b2a730a7-e5f3-4186-8f6f-73c6271ae4ef.png">

https://developer.apple.com/news/?id=2t1chhp3

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed