### PR TITLE
[SDK-3450] API Documentation Generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,6 @@ fastlane/screenshots/
 .swiftpm/
 .build/
 Package.resolved
+
+# DocC
+docs.archive/

--- a/.shiprc
+++ b/.shiprc
@@ -1,8 +1,8 @@
 {
-    "files": {
-        "SimpleKeychain/Info.plist": [],
-        "SimpleKeychain.podspec": []
-    },
-    "postbump": "bundle update",
-    "prefixVersion": false
+  "files": {
+    "SimpleKeychain/Info.plist": [],
+    "SimpleKeychain.podspec": []
+  },
+  "postbump": "bundle update && bundle exec fastlane ios build_docs",
+  "prefixVersion": false
 }

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -151,6 +151,8 @@ GEM
       xcodeproj (>= 1.13.0, < 2.0.0)
       xcpretty (~> 0.3.0)
       xcpretty-travis-formatter (>= 0.0.3)
+    fastlane-plugin-auth0_shipper (0.4.1)
+      semantic (~> 1.5)
     ffi (1.15.5)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
@@ -229,6 +231,7 @@ GEM
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     security (0.1.3)
+    semantic (1.6.1)
     signet (0.16.0)
       addressable (~> 2.8)
       faraday (>= 0.17.3, < 2.0)
@@ -275,6 +278,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods
   fastlane
+  fastlane-plugin-auth0_shipper
 
 BUNDLED WITH
    2.1.4

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -35,4 +35,15 @@ platform :ios do
     perform_release target: 'SimpleKeychain-iOS'
     publish_release repository: 'SimpleKeychain'
   end
+
+  desc "Generate API documentation"
+  lane :build_docs do
+    # Work from project root (defaults to /fastlane)
+    Dir.chdir("..") do
+      # Generate the .doccarchive
+      sh "xcodebuild docbuild -scheme SimpleKeychain-iOS -configuration Release -destination 'generic/platform=iOS' -derivedDataPath docs.archive"
+      # Generate the static site
+      sh "$(xcrun --find docc) process-archive transform-for-static-hosting docs.archive/Build/Products/Release-iphoneos/SimpleKeychain.doccarchive --hosting-base-path SimpleKeychain --output-path docs"
+    end
+  end
 end

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -36,6 +36,11 @@ Runs all the tests in a CI environment
 fastlane ios release
 ```
 Tags the release and pushes the Podspec to CocoaPods
+### ios build_docs
+```
+fastlane ios build_docs
+```
+Generate API documentation
 
 ----
 


### PR DESCRIPTION
### Changes

This PR adds API documentation generation using DocC. The documentation itself will be committed as a seperate PR, for reviewability sake.

### References

See internal ticket SDK-3450

### Testing

Please describe how this can be tested by reviewers. Be specific about anything not tested and reasons why. If helpful, please include manual testing steps as well. 

- [ ] This change adds unit test coverage (or why not)
- [x] This change has been tested on the latest version of the platform/language or why not

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
