### PR TITLE
Improve API docs generation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1,12 +1,11 @@
 default_platform :ios
 
 platform :ios do
-
   before_all do
     setup_circle_ci
   end
 
-  desc "Runs all the tests"
+  desc 'Runs all the tests'
   lane :test do |options|
     scheme = options[:scheme]
     device = options[:device]
@@ -19,31 +18,50 @@ platform :ios do
       )
   end
 
-  desc "Cocoapods library lint"
+  desc 'Cocoapods library lint'
   lane :pod_lint do
     pod_lib_lint(verbose: false, allow_warnings: true)
   end
 
-  desc "Runs all the tests in a CI environment"
+  desc 'Runs all the tests in a CI environment'
   lane :ci do
     # TODO: Run rest of platforms
     test
   end
 
-  desc "Tags the release and pushes the Podspec to CocoaPods"
+  desc 'Tags the release and pushes the Podspec to CocoaPods'
   lane :release do
     perform_release target: 'SimpleKeychain-iOS'
     publish_release repository: 'SimpleKeychain'
   end
 
-  desc "Generate API documentation"
+  desc 'Generate API documentation'
   lane :build_docs do
+    target = 'SimpleKeychain'
+    docs_dir = 'docs'
+    docs_archive = 'docs.archive'
+    redirect_file = <<~HEREDOC
+      <html>
+        <head>
+          <meta http-equiv="refresh" content="0; url=documentation/#{target.downcase}/" />
+        </head>
+        <body>
+          <p>
+            <a href="documentation/#{target.downcase}/">Redirect</a>
+          </p>
+        </body>
+      </html>
+    HEREDOC
     # Work from project root (defaults to /fastlane)
-    Dir.chdir("..") do
+    Dir.chdir('..') do
+      # Clear existing docs
+      FileUtils.rm_r(docs_dir)
       # Generate the .doccarchive
-      sh "xcodebuild docbuild -scheme SimpleKeychain-iOS -configuration Release -destination 'generic/platform=iOS' -derivedDataPath docs.archive"
+      sh "xcodebuild docbuild -scheme #{target}-iOS -configuration Release -destination 'generic/platform=iOS' -derivedDataPath #{docs_archive}"
       # Generate the static site
-      sh "$(xcrun --find docc) process-archive transform-for-static-hosting docs.archive/Build/Products/Release-iphoneos/SimpleKeychain.doccarchive --hosting-base-path SimpleKeychain --output-path docs"
+      sh "$(xcrun --find docc) process-archive transform-for-static-hosting #{docs_archive}/Build/Products/Release-iphoneos/#{target}.doccarchive --hosting-base-path #{target} --output-path #{docs_dir}"
+      # Write redirect file
+      File.write("#{docs_dir}/index.html", redirect_file)
     end
   end
 end


### PR DESCRIPTION
### Changes

This PR updates the API docs generation lane by deleting the docs directory before generating new docs, and adds an `index.html` to the docs root that redirects to `/documentation/simplekeychain/`.

### Testing

* [ ] This change adds unit test coverage
* [ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

* [X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [X] All existing and new tests complete without errors
* [X] All active GitHub checks have passed