### PR TITLE
Make `context` parameter optional

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,4 @@
 // swift-tools-version:5.5
-// The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                        Easily store your user's credentials in the Keychain.
-                       Supports sharing credentials with an Access Group** or through iCloud, and integrating Touch ID / Face ID.
+                       Supports sharing credentials with an Access Group or through iCloud, and integrating Touch ID / Face ID.
                        DESC
   s.homepage         = 'https://github.com/auth0/SimpleKeychain'
   s.license          = 'MIT'

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                        Easily store your user's credentials in the Keychain.
-                       Supports sharing credentials with an Access Group and integrating Touch ID / Face ID through a LAContext instance.
+                       Supports sharing credentials with an Access Group** or through iCloud, and integrating Touch ID / Face ID.
                        DESC
   s.homepage         = 'https://github.com/auth0/SimpleKeychain'
   s.license          = 'MIT'


### PR DESCRIPTION
### Changes

This PR makes the `context` initializer parameter optional, and only adds `kSecAttrAccessible` on macOS when `kSecAttrSynchronizable` is used as well, as that last attribute makes the macOS Keychain behave like the iOS one.
Also, a couple of unit tests were added and the library description in the Podspec was updated.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[X] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[X] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[X] All existing and new tests complete without errors