### PR TITLE
Fix 'access group' capitalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Coverage Status](https://img.shields.io/codecov/c/github/auth0/SimpleKeychain/master.svg?style=flat)
 ![License](https://img.shields.io/github/license/Auth0/SimpleKeychain.svg?style=flat)
 
-Easily store your user's credentials in the Keychain. Supports sharing credentials with an **Access Group** or through **iCloud**, and integrating **Touch ID / Face ID**.
+Easily store your user's credentials in the Keychain. Supports sharing credentials with an **access group** or through **iCloud**, and integrating **Touch ID / Face ID**.
 
 > ⚠️ This library is currently in [**First Availability**](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages). We do not recommend using this library in production yet. As we move towards General Availability, please be aware that releases may contain breaking changes.
 
@@ -31,7 +31,7 @@ Easily store your user's credentials in the Keychain. Supports sharing credentia
   + [Error handling](#error-handling)
 - [**Configuration**](#configuration)
   + [Include additional attributes](#include-additional-attributes)
-  + [Share items with other apps and extensions using an Access Group](#share-items-with-other-apps-and-extensions-using-an-access-group)
+  + [Share items with other apps and extensions using an access group](#share-items-with-other-apps-and-extensions-using-an-access-group)
   + [Share items with other devices through iCloud synchronization](#share-items-with-other-devices-through-icloud-synchronization)
   + [Restrict item accessibility based on device state](#restrict-item-accessibility-based-on-device-state)
   + [Require Touch ID / Face ID to retrieve an item](#require-touch-id--face-id-to-retrieve-an-item)
@@ -166,15 +166,15 @@ When creating the SimpleKeychain instance, specify additional attributes to incl
 let simpleKeychain = SimpleKeychain(attributes: [kSecUseDataProtectionKeychain as String: true])
 ```
 
-### Share items with other apps and extensions using an Access Group
+### Share items with other apps and extensions using an access group
 
-When creating the SimpleKeychain instance, specify the Access Group that the app may share entries with.
+When creating the SimpleKeychain instance, specify the access group that the app may share entries with.
 
 ```swift
 let simpleKeychain = SimpleKeychain(accessGroup: "ABCDEFGH.com.example.myaccessgroup")
 ```
 
-> 💡 For more information on Access Group sharing, see [Sharing Access to Keychain Items Among a Collection of Apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps).
+> 💡 For more information on access group sharing, see [Sharing Access to Keychain Items Among a Collection of Apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps).
 
 ### Share items with other devices through iCloud synchronization
 

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -4,7 +4,7 @@ Pod::Spec.new do |s|
   s.summary          = 'A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS'
   s.description      = <<-DESC
                        Easily store your user's credentials in the Keychain.
-                       Supports sharing credentials with an Access Group or through iCloud, and integrating Touch ID / Face ID.
+                       Supports sharing credentials with an access group or through iCloud, and integrating Touch ID / Face ID.
                        DESC
   s.homepage         = 'https://github.com/auth0/SimpleKeychain'
   s.license          = 'MIT'

--- a/SimpleKeychain/SimpleKeychain.swift
+++ b/SimpleKeychain/SimpleKeychain.swift
@@ -8,7 +8,7 @@ typealias RetrieveFunction = (_ query: CFDictionary, _ result: UnsafeMutablePoin
 typealias RemoveFunction = (_ query: CFDictionary) -> OSStatus
 
 /// A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS.
-/// Supports sharing credentials with an **Access Group** or through **iCloud**, and integrating **Touch ID / Face ID**.
+/// Supports sharing credentials with an **access group** or through **iCloud**, and integrating **Touch ID / Face ID**.
 public struct SimpleKeychain {
     let service: String
     let accessGroup: String?
@@ -26,10 +26,10 @@ public struct SimpleKeychain {
     /// Initializes a ``SimpleKeychain`` instance.
     ///
     /// - Parameter service: Name of the service under which to save items. Defaults to the bundle identifier.
-    /// - Parameter accessGroup: Access Group for sharing Keychain items. Defaults to `nil`.
+    /// - Parameter accessGroup: access group for sharing Keychain items. Defaults to `nil`.
     /// - Parameter accessibility: ``Accessibility`` type the stored items will have. Defaults to ``Accessibility/afterFirstUnlock``.
     /// - Parameter accessControlFlags: Access control conditions for `kSecAttrAccessControl`.  Defaults to `nil`.
-    /// - Parameter context: `LAContext` used to access Keychain items. Defaults to a new `LAContext` instance.
+    /// - Parameter context: `LAContext` used to access Keychain items. Defaults to `nil`.
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
     /// - Parameter attributes: Additional attributes to include in every query. Defaults to an empty dictionary.
     /// - Returns: A ``SimpleKeychain`` instance.
@@ -52,7 +52,7 @@ public struct SimpleKeychain {
     /// Initializes a ``SimpleKeychain`` instance.
     ///
     /// - Parameter service: Name of the service under which to save items. Defaults to the bundle identifier.
-    /// - Parameter accessGroup: Access Group for sharing Keychain items. Defaults to `nil`.
+    /// - Parameter accessGroup: access group for sharing Keychain items. Defaults to `nil`.
     /// - Parameter accessibility: ``Accessibility`` type the stored items will have. Defaults to ``Accessibility/afterFirstUnlock``.
     /// - Parameter accessControlFlags: Access control conditions for `kSecAttrAccessControl`.  Defaults to `nil`.
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
@@ -306,6 +306,7 @@ extension SimpleKeychain {
             query[kSecAttrAccessControl as String] = access
         } else {
             #if os(macOS)
+            // See https://developer.apple.com/documentation/security/ksecattraccessible
             if self.isSynchronizable || query[kSecUseDataProtectionKeychain as String] as? Bool == true {
                 query[kSecAttrAccessible as String] = self.accessibility.rawValue
             }


### PR DESCRIPTION
### Changes

This PR changes 'Access Group' to 'access group' in the README, API docs, and Podfile description to match the way it's used in the [Apple docs](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps).

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors
