### PR TITLE
Add 1.0.0 fa notice to the master README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 
 A wrapper to make it really easy to deal with iOS Keychain and store your user's credentials securely.
 
+> 📣 **The [First Availability](https://auth0.com/docs/troubleshoot/product-lifecycle/product-release-stages) release of SimpleKeychain 1.0.0 is out**
+<br>It includes support for custom properties, synchronization of items through iCloud, and improved error handling. The GA release is planned for the third week of July.
+<br>See [#157](https://github.com/auth0/SimpleKeychain/issues/157) for more information.
+
 ## Key Features
 
 - **Simple interface** to store user's credentials (e.g. JWT) in the Keychain.


### PR DESCRIPTION
### Changes

This PR adds a notice about the new [1.0.0 fa release](https://github.com/auth0/SimpleKeychain/releases/tag/1.0.0-fa) to the master README, for better discoverability.

### Testing

[ ] This change adds unit test coverage (or why not)
[ ] This change has been tested on the latest version of the platform/language or why not

### Checklist

[ ] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[ ] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[ ] All existing and new tests complete without errors
