### PR TITLE
Fix Xcode 14 tvOS builds

### DIFF
--- a/SimpleKeychain/SimpleKeychain.swift
+++ b/SimpleKeychain/SimpleKeychain.swift
@@ -20,7 +20,7 @@ public struct SimpleKeychain {
     var retrieve: RetrieveFunction = SecItemCopyMatching
     var remove: RemoveFunction = SecItemDelete
 
-    #if canImport(LocalAuthentication)
+    #if canImport(LocalAuthentication) && !os(tvOS)
     let context: LAContext?
 
     /// Initializes a ``SimpleKeychain`` instance.
@@ -272,7 +272,7 @@ extension SimpleKeychain {
         if let accessGroup = self.accessGroup {
             query[kSecAttrAccessGroup as String] = accessGroup
         }
-        #if canImport(LocalAuthentication)
+        #if canImport(LocalAuthentication) && !os(tvOS)
         if let context = self.context {
             query[kSecUseAuthenticationContext as String] = context
         }

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -44,7 +44,7 @@ class SimpleKeychainSpec: QuickSpec {
                     expect(sut.attributes["foo"] as? String) == "bar"
                 }
 
-                #if canImport(LocalAuthentication)
+                #if canImport(LocalAuthentication) && !os(tvOS)
                 it("should init with custom local authentication context") {
                     let context = LAContext()
                     sut = SimpleKeychain(context: context)
@@ -253,7 +253,7 @@ class SimpleKeychainSpec: QuickSpec {
                         expect((query[kSecValueData as String] as? Data)).to(beNil())
                         expect((query[kSecAttrAccessGroup as String] as? String)).to(beNil())
                         expect((query[kSecAttrSynchronizable as String] as? Bool)).to(beNil())
-                        #if canImport(LocalAuthentication)
+                        #if canImport(LocalAuthentication) && !os(tvOS)
                         expect((query[kSecUseAuthenticationContext as String] as? LAContext)).to(beNil())
                         #endif
                     }
@@ -298,7 +298,7 @@ class SimpleKeychainSpec: QuickSpec {
                         expect((query[kSecAttrSynchronizable as String] as? Bool)) == sut.isSynchronizable
                     }
 
-                    #if canImport(LocalAuthentication)
+                    #if canImport(LocalAuthentication) && !os(tvOS)
                     it("should include context attribute") {
                         sut = SimpleKeychain(context: LAContext())
                         let query = sut.baseQuery()


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- N/A All new/changed/fixed functionality is covered by tests (or N/A)
- N/A I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

With this PR, SimpleKeychain does not only validate whether `LocalAuthentication` could be imported but also whether the target OS is not tvOS.

### 🎯 Testing

Without this check, compilation for tvOS fails with Xcode 14 (14A309) as `LocalAuthentication` seems to be importable even though `LAContext` is not available:
<img width="1904" alt="Screen Shot 2022-09-14 at 14 28 06" src="https://user-images.githubusercontent.com/993397/190153316-52dbcfde-f1d7-44f3-8dd0-71480dbc3d91.png">
