### PR TITLE
Fix name-space collision bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ let simpleKeychain = SimpleKeychain(sychronizable: true)
 
 ### Restrict item accessibility based on device state
 
-When creating the SimpleKeychain instance, specify a custom accesibility value to be used. The default value is `.afterFirstUnlock`.
+When creating the SimpleKeychain instance, specify a custom accessibility value to be used. The default value is `.afterFirstUnlock`.
 
 ```swift
 let simpleKeychain = SimpleKeychain(accessibility: .whenUnlocked)

--- a/SimpleKeychain.podspec
+++ b/SimpleKeychain.podspec
@@ -18,5 +18,5 @@ Pod::Spec.new do |s|
   s.watchos.deployment_target = '6.2'
 
   s.source_files = 'SimpleKeychain/*.swift'
-  s.swift_versions = ['5.5', '5.6']
+  s.swift_versions = ['5.5', '5.6', '5.7']
 end

--- a/SimpleKeychain/Accessibility.swift
+++ b/SimpleKeychain/Accessibility.swift
@@ -1,7 +1,7 @@
 import Security
 
 /// Represents the accessibility types of Keychain items. It's a mirror of `kSecAttrAccessible` values.
-public enum Accessibility: RawRepresentable {
+public enum SKAccessibility: RawRepresentable {
 
     /// The data in the Keychain item can be accessed only while the device is unlocked by the user.
     /// See [kSecAttrAccessibleWhenUnlocked](https://developer.apple.com/documentation/security/ksecattraccessiblewhenunlocked).

--- a/SimpleKeychain/SimpleKeychain.swift
+++ b/SimpleKeychain/SimpleKeychain.swift
@@ -12,7 +12,7 @@ typealias RemoveFunction = (_ query: CFDictionary) -> OSStatus
 public struct SimpleKeychain {
     let service: String
     let accessGroup: String?
-    let accessibility: Accessibility
+    let accessibility: SKAccessibility
     let accessControlFlags: SecAccessControlCreateFlags?
     let isSynchronizable: Bool
     let attributes: [String: Any]
@@ -27,7 +27,7 @@ public struct SimpleKeychain {
     ///
     /// - Parameter service: Name of the service under which to save items. Defaults to the bundle identifier.
     /// - Parameter accessGroup: access group for sharing Keychain items. Defaults to `nil`.
-    /// - Parameter accessibility: ``Accessibility`` type the stored items will have. Defaults to ``Accessibility/afterFirstUnlock``.
+    /// - Parameter accessibility: ``SKAccessibility`` type the stored items will have. Defaults to ``SKAccessibility/afterFirstUnlock``.
     /// - Parameter accessControlFlags: Access control conditions for `kSecAttrAccessControl`.  Defaults to `nil`.
     /// - Parameter context: `LAContext` used to access Keychain items. Defaults to `nil`.
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
@@ -35,7 +35,7 @@ public struct SimpleKeychain {
     /// - Returns: A ``SimpleKeychain`` instance.
     public init(service: String = Bundle.main.bundleIdentifier!,
                 accessGroup: String? = nil,
-                accessibility: Accessibility = .afterFirstUnlock,
+                accessibility: SKAccessibility = .afterFirstUnlock,
                 accessControlFlags: SecAccessControlCreateFlags? = nil,
                 context: LAContext? = nil,
                 synchronizable: Bool = false,
@@ -53,14 +53,14 @@ public struct SimpleKeychain {
     ///
     /// - Parameter service: Name of the service under which to save items. Defaults to the bundle identifier.
     /// - Parameter accessGroup: access group for sharing Keychain items. Defaults to `nil`.
-    /// - Parameter accessibility: ``Accessibility`` type the stored items will have. Defaults to ``Accessibility/afterFirstUnlock``.
+    /// - Parameter accessibility: ``SKAccessibility`` type the stored items will have. Defaults to ``SKAccessibility/afterFirstUnlock``.
     /// - Parameter accessControlFlags: Access control conditions for `kSecAttrAccessControl`.  Defaults to `nil`.
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
     /// - Parameter attributes: Additional attributes to include in every query. Defaults to an empty dictionary.
     /// - Returns: A ``SimpleKeychain`` instance.
     public init(service: String = Bundle.main.bundleIdentifier!,
                 accessGroup: String? = nil,
-                accessibility: Accessibility = .afterFirstUnlock,
+                accessibility: SKAccessibility = .afterFirstUnlock,
                 accessControlFlags: SecAccessControlCreateFlags? = nil,
                 synchronizable: Bool = false,
                 attributes: [String: Any] = [:]) {

--- a/SimpleKeychain/SimpleKeychain.swift
+++ b/SimpleKeychain/SimpleKeychain.swift
@@ -9,7 +9,7 @@ typealias RemoveFunction = (_ query: CFDictionary) -> OSStatus
 
 /// A simple Keychain wrapper for iOS, macOS, tvOS, and watchOS.
 /// Supports sharing credentials with an **access group** or through **iCloud**, and integrating **Touch ID / Face ID**.
-public struct SimpleKeychain {
+public struct SKSimpleKeychain {
     let service: String
     let accessGroup: String?
     let accessibility: SKAccessibility
@@ -82,7 +82,7 @@ public struct SimpleKeychain {
 
 // MARK: - Retrieve items
 
-public extension SimpleKeychain {
+public extension SKSimpleKeychain {
     /// Retrieves a `String` value from the Keychain.
     ///
     /// ```swift
@@ -128,7 +128,7 @@ public extension SimpleKeychain {
 
 // MARK: - Store items
 
-public extension SimpleKeychain {
+public extension SKSimpleKeychain {
     /// Saves a `String` value with the type `kSecClassGenericPassword` in the Keychain.
     ///
     /// ```swift
@@ -168,7 +168,7 @@ public extension SimpleKeychain {
 
 // MARK: - Delete items
 
-public extension SimpleKeychain {
+public extension SKSimpleKeychain {
     /// Deletes an item from the Keychain.
     ///
     /// ```swift
@@ -202,7 +202,7 @@ public extension SimpleKeychain {
 
 // MARK: - Convenience methods
 
-public extension SimpleKeychain {
+public extension SKSimpleKeychain {
     /// Checks if an item is stored in the Keychain.
     ///
     /// ```swift
@@ -257,7 +257,7 @@ public extension SimpleKeychain {
 
 // MARK: - Queries
 
-extension SimpleKeychain {
+extension SKSimpleKeychain {
     func baseQuery(withKey key: String? = nil, data: Data? = nil) -> [String: Any] {
         var query = self.attributes
         query[kSecClass as String] = kSecClassGenericPassword

--- a/SimpleKeychainTests/AccessibilitySpec.swift
+++ b/SimpleKeychainTests/AccessibilitySpec.swift
@@ -8,64 +8,64 @@ class AccessibilitySpec: QuickSpec {
         describe("raw representable") {
             context("from raw value to case") {
                 it("should map kSecAttrAccessibleWhenUnlocked") {
-                    let sut = Accessibility(rawValue: kSecAttrAccessibleWhenUnlocked)
-                    expect(sut) == Accessibility.whenUnlocked
+                    let sut = SKAccessibility(rawValue: kSecAttrAccessibleWhenUnlocked)
+                    expect(sut) == SKAccessibility.whenUnlocked
                 }
 
                 it("should map kSecAttrAccessibleWhenUnlockedThisDeviceOnly") {
-                    let sut = Accessibility(rawValue: kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
-                    expect(sut) == Accessibility.whenUnlockedThisDeviceOnly
+                    let sut = SKAccessibility(rawValue: kSecAttrAccessibleWhenUnlockedThisDeviceOnly)
+                    expect(sut) == SKAccessibility.whenUnlockedThisDeviceOnly
                 }
 
                 it("should map kSecAttrAccessibleAfterFirstUnlock") {
-                    let sut = Accessibility(rawValue: kSecAttrAccessibleAfterFirstUnlock)
-                    expect(sut) == Accessibility.afterFirstUnlock
+                    let sut = SKAccessibility(rawValue: kSecAttrAccessibleAfterFirstUnlock)
+                    expect(sut) == SKAccessibility.afterFirstUnlock
                 }
 
                 it("should map kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly") {
-                    let sut = Accessibility(rawValue: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
-                    expect(sut) == Accessibility.afterFirstUnlockThisDeviceOnly
+                    let sut = SKAccessibility(rawValue: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly)
+                    expect(sut) == SKAccessibility.afterFirstUnlockThisDeviceOnly
                 }
 
                 it("should map kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly") {
-                    let sut = Accessibility(rawValue: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
-                    expect(sut) == Accessibility.whenPasscodeSetThisDeviceOnly
+                    let sut = SKAccessibility(rawValue: kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly)
+                    expect(sut) == SKAccessibility.whenPasscodeSetThisDeviceOnly
                 }
 
                 it("should map unknown values") {
-                    let sut = Accessibility(rawValue: "foo" as CFString)
-                    expect(sut) == Accessibility.afterFirstUnlock
+                    let sut = SKAccessibility(rawValue: "foo" as CFString)
+                    expect(sut) == SKAccessibility.afterFirstUnlock
                 }
             }
 
             context("from case to raw value") {
                 it("should map whenUnlocked") {
-                    let sut = Accessibility.whenUnlocked.rawValue as String
+                    let sut = SKAccessibility.whenUnlocked.rawValue as String
                     expect(sut) == (kSecAttrAccessibleWhenUnlocked as String)
                 }
 
                 it("should map whenUnlockedThisDeviceOnly") {
-                    let sut = Accessibility.whenUnlockedThisDeviceOnly.rawValue as String
+                    let sut = SKAccessibility.whenUnlockedThisDeviceOnly.rawValue as String
                     expect(sut) == (kSecAttrAccessibleWhenUnlockedThisDeviceOnly as String)
                 }
 
                 it("should map afterFirstUnlock") {
-                    let sut = Accessibility.afterFirstUnlock.rawValue as String
+                    let sut = SKAccessibility.afterFirstUnlock.rawValue as String
                     expect(sut) == (kSecAttrAccessibleAfterFirstUnlock as String)
                 }
 
                 it("should map afterFirstUnlockThisDeviceOnly") {
-                    let sut = Accessibility.afterFirstUnlockThisDeviceOnly.rawValue as String
+                    let sut = SKAccessibility.afterFirstUnlockThisDeviceOnly.rawValue as String
                     expect(sut) == (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly as String)
                 }
 
                 it("should map whenPasscodeSetThisDeviceOnly") {
-                    let sut = Accessibility.whenPasscodeSetThisDeviceOnly.rawValue as String
+                    let sut = SKAccessibility.whenPasscodeSetThisDeviceOnly.rawValue as String
                     expect(sut) == (kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly as String)
                 }
 
                 it("should map whenPasscodeSetThisDeviceOnly") {
-                    let sut = Accessibility.whenPasscodeSetThisDeviceOnly.rawValue as String
+                    let sut = SKAccessibility.whenPasscodeSetThisDeviceOnly.rawValue as String
                     expect(sut) == (kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly as String)
                 }
             }

--- a/SimpleKeychainTests/SimpleKeychainErrorSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainErrorSpec.swift
@@ -132,7 +132,7 @@ class SimpleKeychainErrorSpec: QuickSpec {
                 expect(sut.localizedDescription) == message
             }
         }
- 
+
         describe("code") {
             context("from status to code") {
                 it("should map errSecUnimplemented") {

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -11,7 +11,7 @@ let KeychainService = "com.auth0.simplekeychain.tests"
 class SimpleKeychainSpec: QuickSpec {
     override func spec() {
         describe("SimpleKeychain") {
-            var sut: SimpleKeychain!
+            var sut: SKSimpleKeychain!
 
             afterEach {
                 try? sut.deleteAll()
@@ -19,7 +19,7 @@ class SimpleKeychainSpec: QuickSpec {
 
             describe("initialization") {
                 it("should init with default values") {
-                    sut = SimpleKeychain()
+                    sut = SKSimpleKeychain()
                     expect(sut.accessGroup).to(beNil())
                     expect(sut.service) == Bundle.main.bundleIdentifier
                     expect(sut.accessibility) == SKAccessibility.afterFirstUnlock
@@ -29,7 +29,7 @@ class SimpleKeychainSpec: QuickSpec {
                 }
 
                 it("should init with custom values") {
-                    sut = SimpleKeychain(service: KeychainService,
+                    sut = SKSimpleKeychain(service: KeychainService,
                                          accessGroup: "Group",
                                          accessibility: .whenUnlocked,
                                          accessControlFlags: .userPresence,
@@ -47,7 +47,7 @@ class SimpleKeychainSpec: QuickSpec {
                 #if canImport(LocalAuthentication) && !os(tvOS)
                 it("should init with custom local authentication context") {
                     let context = LAContext()
-                    sut = SimpleKeychain(context: context)
+                    sut = SKSimpleKeychain(context: context)
                     expect(sut.context).to(be(context))
                 }
                 #endif
@@ -57,7 +57,7 @@ class SimpleKeychainSpec: QuickSpec {
                 var key: String!
 
                 beforeEach({
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                     key = UUID().uuidString
                 })
 
@@ -88,7 +88,7 @@ class SimpleKeychainSpec: QuickSpec {
                 var key: String!
 
                 beforeEach {
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                     key = UUID().uuidString
                     try! sut.set("foo", forKey: key)
                 }
@@ -135,7 +135,7 @@ class SimpleKeychainSpec: QuickSpec {
                 var key: String!
 
                 beforeEach {
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                     key = UUID().uuidString
                     try! sut.set("foo", forKey: key)
                 }
@@ -183,7 +183,7 @@ class SimpleKeychainSpec: QuickSpec {
                 var key: String!
 
                 beforeEach {
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                     key = UUID().uuidString
                     try! sut.set("foo", forKey: key)
                 }
@@ -202,7 +202,7 @@ class SimpleKeychainSpec: QuickSpec {
 
                 beforeEach {
                     try! sut.deleteAll()
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                     keys.append(UUID().uuidString)
                     keys.append(UUID().uuidString)
                     keys.append(UUID().uuidString)
@@ -241,7 +241,7 @@ class SimpleKeychainSpec: QuickSpec {
 
             describe("queries") {
                 beforeEach {
-                    sut = SimpleKeychain(service: KeychainService)
+                    sut = SKSimpleKeychain(service: KeychainService)
                 }
 
                 context("base query") {
@@ -261,7 +261,7 @@ class SimpleKeychainSpec: QuickSpec {
                     it("should include additional attributes") {
                         let key = "foo"
                         let value = "bar"
-                        sut = SimpleKeychain(attributes: [key: value])
+                        sut = SKSimpleKeychain(attributes: [key: value])
                         let query = sut.baseQuery()
                         expect((query[key] as? String)) == value
                     }
@@ -269,7 +269,7 @@ class SimpleKeychainSpec: QuickSpec {
                     it("should supersede additional attributes") {
                         let key = kSecAttrService as String
                         let value = "foo"
-                        sut = SimpleKeychain(attributes: [key: value])
+                        sut = SKSimpleKeychain(attributes: [key: value])
                         let query = sut.baseQuery()
                         expect((query[key] as? String)) == sut.service
                     }
@@ -287,20 +287,20 @@ class SimpleKeychainSpec: QuickSpec {
                     }
 
                     it("should include access group attribute") {
-                        sut = SimpleKeychain(accessGroup: "foo")
+                        sut = SKSimpleKeychain(accessGroup: "foo")
                         let query = sut.baseQuery()
                         expect((query[kSecAttrAccessGroup as String] as? String)) == sut.accessGroup
                     }
 
                     it("should include synchronizable attribute") {
-                        sut = SimpleKeychain(synchronizable: true)
+                        sut = SKSimpleKeychain(synchronizable: true)
                         let query = sut.baseQuery()
                         expect((query[kSecAttrSynchronizable as String] as? Bool)) == sut.isSynchronizable
                     }
 
                     #if canImport(LocalAuthentication) && !os(tvOS)
                     it("should include context attribute") {
-                        sut = SimpleKeychain(context: LAContext())
+                        sut = SKSimpleKeychain(context: LAContext())
                         let query = sut.baseQuery()
                         expect((query[kSecUseAuthenticationContext as String] as? LAContext)) == sut.context
                     }
@@ -350,7 +350,7 @@ class SimpleKeychainSpec: QuickSpec {
                     }
 
                     it("should include access control attribute") {
-                        sut = SimpleKeychain(accessControlFlags: .userPresence)
+                        sut = SKSimpleKeychain(accessControlFlags: .userPresence)
                         let query = sut.setQuery(forKey: "foo", data: Data())
                         expect(query[kSecAttrAccessControl as String]).toNot(beNil())
                     }
@@ -362,7 +362,7 @@ class SimpleKeychainSpec: QuickSpec {
                     }
 
                     it("should include accessibility attribute when iCloud sharing is enabled") {
-                        sut = SimpleKeychain(synchronizable: true)
+                        sut = SKSimpleKeychain(synchronizable: true)
                         let query = sut.setQuery(forKey: "foo", data: Data())
                         let expectedAccessibility = sut.accessibility.rawValue as String
                         expect((query[kSecAttrAccessible as String] as? String)) == expectedAccessibility
@@ -370,7 +370,7 @@ class SimpleKeychainSpec: QuickSpec {
 
                     it("should include accessibility attribute when data protection is enabled") {
                         let attributes = [kSecUseDataProtectionKeychain as String: kCFBooleanTrue as Any]
-                        sut = SimpleKeychain(attributes: attributes)
+                        sut = SKSimpleKeychain(attributes: attributes)
                         let query = sut.setQuery(forKey: "foo", data: Data())
                         let expectedAccessibility = sut.accessibility.rawValue as String
                         expect((query[kSecAttrAccessible as String] as? String)) == expectedAccessibility

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -22,7 +22,7 @@ class SimpleKeychainSpec: QuickSpec {
                     sut = SimpleKeychain()
                     expect(sut.accessGroup).to(beNil())
                     expect(sut.service) == Bundle.main.bundleIdentifier
-                    expect(sut.accessibility) == Accessibility.afterFirstUnlock
+                    expect(sut.accessibility) == SKAccessibility.afterFirstUnlock
                     expect(sut.accessControlFlags).to(beNil())
                     expect(sut.isSynchronizable) == false
                     expect(sut.attributes).to(beEmpty())
@@ -37,7 +37,7 @@ class SimpleKeychainSpec: QuickSpec {
                                          attributes: ["foo": "bar"])
                     expect(sut.accessGroup) == "Group"
                     expect(sut.service) == KeychainService
-                    expect(sut.accessibility) == Accessibility.whenUnlocked
+                    expect(sut.accessibility) == SKAccessibility.whenUnlocked
                     expect(sut.accessControlFlags) == .userPresence
                     expect(sut.isSynchronizable) == true
                     expect(sut.attributes.count) == 1

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -30,11 +30,11 @@ class SimpleKeychainSpec: QuickSpec {
 
                 it("should init with custom values") {
                     sut = SKSimpleKeychain(service: KeychainService,
-                                         accessGroup: "Group",
-                                         accessibility: .whenUnlocked,
-                                         accessControlFlags: .userPresence,
-                                         synchronizable: true,
-                                         attributes: ["foo": "bar"])
+                                           accessGroup: "Group",
+                                           accessibility: .whenUnlocked,
+                                           accessControlFlags: .userPresence,
+                                           synchronizable: true,
+                                           attributes: ["foo": "bar"])
                     expect(sut.accessGroup) == "Group"
                     expect(sut.service) == KeychainService
                     expect(sut.accessibility) == SKAccessibility.whenUnlocked

--- a/V1_MIGRATION_GUIDE.md
+++ b/V1_MIGRATION_GUIDE.md
@@ -49,7 +49,7 @@ The deployment targets for each platform were raised to:
 ## Types Removed
 
 - The `A0SimpleKeychainError` enum was removed in favor of the new `SimpleKeychainError` enum.
-- The `A0SimpleKeychainItemAccessible` enum was removed in favor of the new `Accessibility` enum.
+- The `A0SimpleKeychainItemAccessible` enum was removed in favor of the new `SKAccessibility` enum.
 - The `A0ErrorDomain` macro was removed.
 - The `A0LocalAuthenticationCapable` macro was removed.
 
@@ -57,9 +57,9 @@ The deployment targets for each platform were raised to:
 
 ### SimpleKeychain Struct
 
-#### `defaultAccessiblity`
+#### `defaultAccessibility`
 
-The property `defaultAccessiblity` was removed in favor of the new `accessibility` initalizer parameter.
+The property `defaultAccessiblity` was removed in favor of the new `accessibility` initializer parameter.
 
 <details>
   <summary>Before / After</summary>
@@ -191,7 +191,7 @@ The `error` parameter was removed from the `data(forKey:)` method, as it now thr
 ### SimpleKeychain Struct
 
 - `kSecUseAuthenticationUI` is no longer used. Configure whether the user should be prompted for authentication through an `LAContext` instance instead, using the `LAContext.interactionNotAllowed` property.
-- The `hasItem(forKey:)` method no longer retuns `false` whenever any error occurs. Now it only returns `false` when the error is `errSecItemNotFound`.
+- The `hasItem(forKey:)` method no longer returns `false` whenever any error occurs. Now it only returns `false` when the error is `errSecItemNotFound`.
 
 ---
 


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [x] All new/changed/fixed functionality is covered by tests (or N/A)
- [x] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be unceremoniously closed.
-->

### 📋 Changes

<!--
Describe both what is changing and why this is important. Include:

- Types and methods added, deleted, deprecated, or changed
- A summary of usage if this is a new feature or a change to a public API
-->

1. Adds support for using with Swift 5.7 (Xcode 14)
2. Fixes name-space collisions that prevent integrating in some scenarios. 

The compile-time errors due to this bug are preventing us from updating Auth0 to the latest version. This PR adds a "SK" prefix to two items to fix the bug. This could be changed to anything, even reverting back to "A0". Another option is to rename the module to something like "SimpleKeychainKit" instead of renaming the struct and enum that was done in this PR.

### 📎 References

<!--
Add relevant links supporting this change, such as:

- GitHub issue/PR number addressed or fixed
- Auth0 Community post
- StackOverflow answer
- Related pull requests/issues from other repositories

If there are no references, simply delete this section.
-->

In SimpleKeychain v1.0.0 a struct and an enum were renamed to drop the "A0" prefix. This causes namespace confusion for Swift. This is due to a known Swift bug: https://github.com/apple/swift/issues/56573

<details>
<summary>Warnings in SimpleKeychain</summary>

<img width="1512" alt="Screen Shot 2022-09-23 at 3 47 57 PM" src="https://user-images.githubusercontent.com/11352698/192353519-413e1021-1129-407b-a302-fc6bf5a0a28b.png">

<img width="1512" alt="Screen Shot 2022-09-23 at 3 48 05 PM" src="https://user-images.githubusercontent.com/11352698/192353532-478bdbad-c0a2-49f0-b525-ef97ff270d15.png">

</details>

<details>
<summary>Errors in End User project</summary>

<img width="1573" alt="Screen Shot 2022-09-22 at 2 34 48 PM" src="https://user-images.githubusercontent.com/11352698/192353579-e9218795-1041-4d3c-9639-78515bae0df2.png">

</details>



### 🎯 Testing

<!--
Describe how this can be tested by reviewers. Be specific about anything not tested and why. Include any manual steps for testing end-to-end, or for testing functionality not covered by unit tests.
-->
This is a simple name change so the framework should compile as it does currently. Unit tests were updated with the new names and all pass successfully.