### PR TITLE
Reduce permissions of GH actions and limit its triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,11 @@
 name: CI
-on: push
+on:
+    pull_request:
+      types:
+        - opened
+        - synchronize
+
+permissions: {}
 
 jobs:
     test:


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR sets the permissions of the GitHub Actions workflow to `permissions: {}`, as none of the jobs require elevated permissions. Also, the events that trigger the workflow were changed from `push` (run on push to any branch) to only when a PR is created, or new commits are pushed to one.