### PR TITLE
Update unit tests to compile with Xcode 15

### DIFF
--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -388,7 +388,7 @@ class SimpleKeychainSpec: AsyncSpec {
     }
 }
 
-public func containBaseQuery(_ baseQuery: [String: Any]) -> Predicate<[String: Any]> {
+public func containBaseQuery(_ baseQuery: [String: Any]) -> Nimble.Predicate<[String: Any]> {
     return Predicate<[String: Any]>.define("contains base query <\(baseQuery)>") { expression, failureMessage in
         guard let actual = try expression.evaluate() else {
             return PredicateResult(status: .doesNotMatch, message: failureMessage)


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR disambiguates the `Predicate` type used in the custom matchers to use [Nimble's](https://github.com/Quick/Nimble) `Predicate` instead of the [newly introduced type](https://developer.apple.com/documentation/foundation/predicate) in Swift 5.9.