### PR TITLE
Update Platforms Support Policy in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,6 @@ The minimum supported Swift minor version is the one released with the oldest-su
 
 ### Platforms
 
-Only the last 4 major platform versions are supported, starting from:
-
-- iOS **12**
-- macOS **10.15**
-- macCatalyst **13**
-- tvOS **12**
-- watchOS **6.2**
-
 Once a platform version becomes unsupported, dropping it from SimpleKeychain **will not be considered a breaking change**, and will be done in a **minor** release. For example, iOS 13 will cease to be supported when iOS 17 gets released, and SimpleKeychain will be able to drop it in a minor release.
 
 In the case of macOS, the yearly named releases are considered a major platform version for the purposes of this Policy, regardless of the actual version numbers.

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Migrating from 0.x? Check the [Migration Guide](V1_MIGRATION_GUIDE.md).
 
 ### Requirements
 
-- iOS 12.0+ / macOS 10.15+ / tvOS 12.0+ / watchOS 6.2+
-- Xcode 13.x / 14.x
-- Swift 5.x
+- iOS 13.0+ / macOS 11.0+ / tvOS 13.0+ / watchOS 7.0+
+- Xcode 14.x / 15.x
+- Swift 5.7+
 
 > **Note**
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a Pull Request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull Requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

The **Support Policy** section of the README includes a bit that states the initial versions from which the "last 4 major versions" policy will apply.

This bit [was recently removed](https://github.com/auth0/Auth0.swift/pull/808) from Auth0.swift's README because it resulted in confusion regarding the currently supported platform versions.

This PR removes it from SimpleKeychain's README as well, and updates the versions in the **Requirements** section.