### PR TITLE
Use the new syntax for Markdown admonitions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-> **Note**
+> [!IMPORTANT]
 > Tests must be added for all new functionality. Existing tests must be updated for all changed/fixed functionality, where applicable. All tests must complete without errors. All new functionality must be documented as well.
 
 ## Environment setup

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -34,7 +34,7 @@ When creating the SimpleKeychain instance, specify the access group that the app
 let simpleKeychain = SimpleKeychain(accessGroup: "ABCDEFGH.com.example.myaccessgroup")
 ```
 
-> **Note**
+> [!NOTE]
 > For more information on access group sharing, see [Sharing Access to Keychain Items Among a Collection of Apps](https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps).
 
 ## Share items with other devices through iCloud synchronization
@@ -45,7 +45,7 @@ When creating the SimpleKeychain instance, set `synchronizable` to `true` to ena
 let simpleKeychain = SimpleKeychain(sychronizable: true)
 ```
 
-> **Note**
+> [!NOTE]
 > For more information on iCloud synchronization, check the [kSecAttrSynchronizable documentation](https://developer.apple.com/documentation/security/ksecattrsynchronizable).
 
 ## Restrict item accessibility based on device state
@@ -56,7 +56,7 @@ When creating the SimpleKeychain instance, specify a custom accesibility value t
 let simpleKeychain = SimpleKeychain(accessibility: .whenUnlocked)
 ```
 
-> **Note**
+> [!NOTE]
 > For more information on accessibility, see [Restricting Keychain Item Accessibility](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility).
 
 ## Require Touch ID / Face ID to retrieve an item
@@ -70,7 +70,7 @@ let simpleKeychain = SimpleKeychain(accessControlFlags: .biometryCurrentSet,
                                     context: context)
 ```
 
-> **Note**
+> [!NOTE]
 > For more information on access control, see [Restricting Keychain Item Accessibility](https://developer.apple.com/documentation/security/keychain_services/keychain_items/restricting_keychain_item_accessibility).
 
 ---

--- a/README.md
+++ b/README.md
@@ -187,6 +187,6 @@ Please do not report security vulnerabilities on the public GitHub issue tracker
   </picture>
 </p>
 
-<p align="center">Auth0 is an easy to implement, adaptable authentication and authorization platform. To learn more checkout <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
+<p align="center">Auth0 is an easy-to-implement, adaptable authentication and authorization platform. To learn more check out <a href="https://auth0.com/why-auth0">Why Auth0?</a></p>
 
 <p align="center">This project is licensed under the MIT license. See the <a href="./LICENSE"> LICENSE</a> file for more info.</p>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Migrating from 0.x? Check the [Migration Guide](V1_MIGRATION_GUIDE.md).
 - Xcode 13.x / 14.x
 - Swift 5.x
 
-> **Note**
+> [!IMPORTANT]
 > Check the [Support Policy](#support-policy) to learn when dropping Xcode, Swift, and platform versions will not be considered a **breaking change**.
 
 ### Installation


### PR DESCRIPTION
<!--
❗ For general support or usage questions, use the Auth0 Community forums or raise a support ticket.

By submitting a pull request to this repository, you agree to the terms within the Auth0 Code of Conduct: https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md.
-->

- [ ] All new/changed/fixed functionality is covered by tests (or N/A)
- [ ] I have added documentation for all new/changed functionality (or N/A)

<!--
❗ All the above items are required. Pull requests with an incomplete or missing checklist will be closed.
-->

### 📋 Changes

This PR updates all the Markdown documentation to use the new admonitions syntax supported by GitHub. The previous syntax is not supported anymore.

<img width="907" alt="Screenshot 2023-12-13 at 16 49 40" src="https://github.com/auth0/Auth0.swift/assets/5055789/bdfba20d-388a-4c82-b380-3dd15362c882">