### PR TITLE
Avoid default service crash without bundle identifier

### DIFF
--- a/SimpleKeychain/SimpleKeychain.swift
+++ b/SimpleKeychain/SimpleKeychain.swift
@@ -35,7 +35,7 @@ public struct SimpleKeychain: @unchecked Sendable {
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
     /// - Parameter attributes: Additional attributes to include in every query. Defaults to an empty dictionary.
     /// - Returns: A ``SimpleKeychain`` instance.
-    public init(service: String = Bundle.main.bundleIdentifier!,
+    public init(service: String = Bundle.main.bundleIdentifier ?? "SimpleKeychain",
                 accessGroup: String? = nil,
                 accessibility: Accessibility = .afterFirstUnlock,
                 accessControlFlags: SecAccessControlCreateFlags? = nil,
@@ -61,7 +61,7 @@ public struct SimpleKeychain: @unchecked Sendable {
     /// - Parameter synchronizable: Whether the items should be synchronized through iCloud. Defaults to `false`.
     /// - Parameter attributes: Additional attributes to include in every query. Defaults to an empty dictionary.
     /// - Returns: A ``SimpleKeychain`` instance.
-    public init(service: String = Bundle.main.bundleIdentifier!,
+    public init(service: String = Bundle.main.bundleIdentifier ?? "SimpleKeychain",
                 accessGroup: String? = nil,
                 accessibility: Accessibility = .afterFirstUnlock,
                 accessControlFlags: SecAccessControlCreateFlags? = nil,

--- a/SimpleKeychainTests/SimpleKeychainSpec.swift
+++ b/SimpleKeychainTests/SimpleKeychainSpec.swift
@@ -23,7 +23,7 @@ class SimpleKeychainTests: XCTestCase {
     
     func testInitializationWithDefaultValues() {
         XCTAssertEqual(sut.accessGroup, nil)
-        XCTAssertEqual(sut.service, Bundle.main.bundleIdentifier)
+        XCTAssertEqual(sut.service, Bundle.main.bundleIdentifier ?? "SimpleKeychain")
         XCTAssertEqual(sut.accessibility, Accessibility.afterFirstUnlock)
         XCTAssertEqual(sut.accessControlFlags, nil)
         XCTAssertEqual(sut.isSynchronizable, false)
@@ -374,4 +374,3 @@ public extension Dictionary where Key == String, Value == Any {
 public func ==(lhs: [String: Any], rhs: [String: Any]) -> Bool {
     return NSDictionary(dictionary: lhs).isEqual(to: rhs)
 }
-


### PR DESCRIPTION
## Summary
- avoid force-unwrapping Bundle.main.bundleIdentifier for the default service value
- fall back to SimpleKeychain when no bundle identifier is available
- update the default initialization test for the fallback

## Validation
- Not run locally: Swift toolchain is not installed on this Windows machine.
- Local checkout note: generated docs contain Windows-invalid paths, so the source was inspected from an archive excluding docs.